### PR TITLE
Fix get_revision for multiple repo sources

### DIFF
--- a/jenkinsapi/build.py
+++ b/jenkinsapi/build.py
@@ -34,8 +34,10 @@ class Build(JenkinsBase):
         return self._data["result"]
 
     def get_revision(self):
-        for set in self._data["changeSet"]["revisions"]:
-            return set["revision"]
+        maxRevision = 0
+        for repoPathSet in self._data["changeSet"]["revisions"]:
+            maxRevision = max(repoPathSet["revision"], maxRevision)
+        return maxRevision
 
     def get_duration(self):
         return self._data["duration"]


### PR DESCRIPTION
Up for debate is whether you guys want to keep '0' as the default for maxRevision or change it to 'None.
