### PR TITLE
FIX: TypeError: 'NoneType' object is unsubscriptable in job._buildid_for_type

### DIFF
--- a/jenkinsapi/job.py
+++ b/jenkinsapi/job.py
@@ -102,6 +102,8 @@ class Job(JenkinsBase):
         """Gets a buildid for a given type of build"""
         KNOWNBUILDTYPES=["lastSuccessfulBuild", "lastBuild", "lastCompletedBuild"]
         assert buildtype in KNOWNBUILDTYPES
+        if self._data[buildtype] == None:
+            return None
         buildid = self._data[buildtype]["number"]
         assert type(buildid) == int, "Build ID should be an integer, got %s" % repr( buildid )
         return buildid


### PR DESCRIPTION
If job does not have any builds self._data[buildtype]["number"] raise "TypeError: 'NoneType' object is unsubscriptable" 
Return "None" instead.
