### PR TITLE
Adding support to get upstream jobs and builds

### DIFF
--- a/jenkinsapi/build.py
+++ b/jenkinsapi/build.py
@@ -58,7 +58,7 @@ class Build(JenkinsBase):
         :return: String or None
         """
         try:
-    		return self.get_actions()['causes'][0]['upstreamProject']
+            return self.get_actions()['causes'][0]['upstreamProject']
         except KeyError:
             return None
 
@@ -78,7 +78,7 @@ class Build(JenkinsBase):
         :return: int or None
         """
         try:
-    		return int(self.get_actions()['causes'][0]['upstreamBuild'])
+            return int(self.get_actions()['causes'][0]['upstreamBuild'])
         except KeyError:
             return None
 
@@ -88,7 +88,7 @@ class Build(JenkinsBase):
         :return: String or None
         """
         try:
-    		return self.get_actions()['parameters'][0]['value']
+            return self.get_actions()['parameters'][0]['value']
         except KeyError:
             return None
 
@@ -108,7 +108,7 @@ class Build(JenkinsBase):
         :return: int or None
         """
         try:
-    		return int(self.get_actions()['parameters'][1]['value'])
+            return int(self.get_actions()['parameters'][1]['value'])
         except KeyError:
             return None
 


### PR DESCRIPTION
In the case Jenkins has downstream/upstream jobs, this change adds more flexibility to handle them.
It is just adding some methods to get the upstream job or/and the master job as long as their corresponding build.
If the build doesn't have any upstream or master job/build it doesn't fail, it just return None
