### PR TITLE
A build should have resultset even though having a status failure

### DIFF
--- a/jenkinsapi/build.py
+++ b/jenkinsapi/build.py
@@ -243,8 +243,6 @@ class Build(JenkinsBase):
         if self.STR_TOTALCOUNT not in self.get_actions():
             raise NoResults( "%s does not have any published results" % str(self) )
         buildstatus = self.get_status()
-        if buildstatus in [ STATUS_FAIL, RESULTSTATUS_FAILURE, STATUS_ABORTED ]:
-            raise FailedNoResults( self.STR_TPL_NOTESTS_ERR % ( str(self), buildstatus ) )
         if not self.get_actions()[self.STR_TOTALCOUNT]:
             raise NoResults( self.STR_TPL_NOTESTS_ERR % ( str(self), buildstatus ) )
         obj_results = ResultSet( result_url, build=self )


### PR DESCRIPTION
Currently the build object always raises an exception if it has a failure status but even so it could has results, so, stablishing the condition of having the totalCount element in the get_actions() list is more than enough to be able to know if the build has resultset. I've removed the lines that raise an exception if the status is not ok.
