### PR TITLE
Please add jenkinsapi.api.get_build

### DIFF
--- a/jenkinsapi/api.py
+++ b/jenkinsapi/api.py
@@ -34,6 +34,14 @@ def get_latest_complete_build(jenkinsurl, jobname):
     job = jenkinsci[jobname]
     return job.get_last_completed_build()
 
+def get_build(jenkinsurl, jobname, build_no):
+    """
+    A convenience function to fetch down the test results from a jenkins job by build number.
+    """
+    jenkinsci = Jenkins(jenkinsurl)
+    job = jenkinsci[jobname]
+    return job.get_build( build_no )
+
 def get_artifacts( jenkinsurl, jobid=None, build_no=None, proxyhost=None, proxyport=None, proxyuser=None, proxypass=None ):
     """
     Find all the artifacts for the latest build of a job.


### PR DESCRIPTION
A handy shortcut for interactive use, if nothing else.  

get_latest_complete_build (and related) are great, but if you want to get a specific build by build number, say for interactive debugging, it is annoying to have to use the longer API.
