### PR TITLE
delete_job does not work

### DIFF
--- a/jenkinsapi/jenkins.py
+++ b/jenkinsapi/jenkins.py
@@ -42,6 +42,12 @@ class Jenkins(JenkinsBase):
         self.proxypass = proxypass
         JenkinsBase.__init__(self, baseurl, formauth=formauth)
 
+    def _clone(self):
+        return Jenkins(self.baseurl, username=self.username,
+                       password=self.password, proxyhost=self.proxyhost,
+                       proxyport=self.proxyport, proxyuser=self.proxyuser,
+                       proxypass=self.proxypass, formauth=self.formauth)
+
     def get_proxy_auth(self):
         return self.proxyhost, self.proxyport, self.proxyuser, self.proxypass
 
@@ -162,10 +168,7 @@ class Jenkins(JenkinsBase):
                                'from': jobname})
         copy_job_url = urlparse.urljoin(self.baseurl, "createItem?%s" % qs)
         self.post_data(copy_job_url, '')
-        newjk = Jenkins(self.baseurl, username=self.username,
-                        password=self.password, proxyhost=self.proxyhost,
-                        proxyport=self.proxyport, proxyuser=self.proxyuser,
-                        proxypass=self.proxypass, formauth=self.formauth)
+        newjk = self._clone()
         return newjk.get_job(newjobname)
 
     def delete_job(self, jobname):
@@ -174,12 +177,9 @@ class Jenkins(JenkinsBase):
         :param jobname: name of a exist job, str
         :return: new jenkins_obj
         """
-        delete_job_url = urlparse.urljoin(Jenkins(self.baseurl).get_job(jobname).baseurl, "doDelete" )
+        delete_job_url = urlparse.urljoin(self._clone().get_job(jobname).baseurl, "doDelete" )
         self.post_data(delete_job_url, '')
-        newjk = Jenkins(self.baseurl, username=self.username,
-                        password=self.password, proxyhost=self.proxyhost,
-                        proxyport=self.proxyport, proxyuser=self.proxyuser,
-                        proxypass=self.proxypass, formauth=self.formauth)
+        newjk = self._clone()
         return newjk
 
     def iteritems(self):
@@ -227,10 +227,7 @@ class Jenkins(JenkinsBase):
     def delete_view_by_url(self, str_url):
         url = "%s/doDelete" %str_url
         self.post_data(url, '')
-        newjk = Jenkins(self.baseurl, username=self.username,
-                        password=self.password, proxyhost=self.proxyhost,
-                        proxyport=self.proxyport, proxyuser=self.proxyuser,
-                        proxypass=self.proxypass, formauth=self.formauth)
+        newjk = self._clone()
         return newjk
 
     def create_view(self, str_view_name, people=None):


### PR DESCRIPTION
delete_job make a call to get_job without the auth info. This results in a 403 if auth is enabled.
