### PR TITLE
Fix for https://github.com/salimfadhley/jenkinsapi/issues/53

### DIFF
--- a/jenkinsapi/jenkinsbase.py
+++ b/jenkinsapi/jenkinsbase.py
@@ -68,6 +68,8 @@ class JenkinsBase(object):
             stream = fn_urlopen(url)
             result = eval(stream.read())
         except urllib2.HTTPError, e:
+            if e.code == 404:
+                raise
             log.warn("Error reading %s" % url)
             log.exception(e)
             raise

--- a/jenkinsapi/utils/retry.py
+++ b/jenkinsapi/utils/retry.py
@@ -1,5 +1,6 @@
 import logging
 import time
+import urllib2
 
 log = logging.getLogger( __name__ )
 
@@ -25,6 +26,11 @@ def retry_function( tries, fn, *args, **kwargs ):
             if attempt > 0:
                 log.info( "Result obtained after attempt %i" % attemptno )
             return result
+        except urllib2.HTTPError, e:
+            if e.code == 404:
+                raise
+
+            log.exception(e)
         except Exception, e:
             if type(e) in IGNORE_EXCEPTIONS:
                 # Immediatly raise in some cases.


### PR DESCRIPTION
Changed retry_function to return 404s directly, as in that
case we have reached the server, so it is not a network or internal
server error, redirect, proxy failure or anything like that.

Artifact.valid will consider the fingerprint valid if the
fingerprint is not available at server (but it can still exist, so
it cannot be claimed as invalid with certainty).

See issue https://github.com/salimfadhley/jenkinsapi/issues/53.
