### PR TITLE
Fixed crash on None value in JenkinsBase._data object

### DIFF
--- a/jenkinsapi/build.py
+++ b/jenkinsapi/build.py
@@ -254,6 +254,7 @@ class Build(JenkinsBase):
     def get_actions(self):
         all_actions = {}
         for dct_action in self._data["actions"]:
+            if dct_action is None: continue
             all_actions.update( dct_action )
         return all_actions
 


### PR DESCRIPTION
I found that some of the actions might be None on some jobs, while trying to access the parameters.

This is a simple null value check. 

It is worth checking if the fact that a None exist in the _data object is valid in the first place... I don't know the code well enough to say though.
