### PR TITLE
[FIX] ISSUE 70 - Jenkins need POST params and not GET params

### DIFF
--- a/jenkinsapi/jenkinsbase.py
+++ b/jenkinsapi/jenkinsbase.py
@@ -1,3 +1,4 @@
+import urllib
 import urllib2
 import logging
 import pprint
@@ -86,10 +87,11 @@ class JenkinsBase(object):
             raise
         return result
 
-    def hit_url(self, url ):
+    def hit_url(self, url, params = None):
         fn_urlopen = self.get_jenkins_obj().get_opener()
         try:
-            stream = fn_urlopen( url )
+            if params: stream = fn_urlopen( url, urllib.urlencode(params) )
+            else: stream = fn_urlopen( url )
             html_result = stream.read()
         except urllib2.HTTPError, e:
             log.debug( "Error reading %s" % url )


### PR DESCRIPTION
Since the v1.502 of Jenkins, jobs can not be launched with GET params.
There is this error message : 
"You must use POST method to trigger builds ..."

This pull request have to fix the problem.
