### PR TITLE
Add get_params and get_params_list to Job

### DIFF
--- a/jenkinsapi/job.py
+++ b/jenkinsapi/job.py
@@ -413,3 +413,29 @@ class Job(JenkinsBase):
             pass
         return True
 
+    def get_params(self):
+        """
+        Get the parameters for this job. Format varies by parameter type. Here
+        is an example string parameter:
+            {
+                'type': 'StringParameterDefinition',
+                'description': 'Parameter description',
+                'defaultParameterValue': {'value': 'default value'},
+                'name': 'FOO_BAR'
+            }
+        """
+        for action in self._data['actions']:
+            try:
+                for param in action['parameterDefinitions']:
+                    yield param
+            except KeyError:
+                continue
+
+    def get_params_list(self):
+        """
+        Gets the list of parameter names for this job.
+        """
+        params = []
+        for param in self.get_params():
+            params.append(param['name'])
+        return params


### PR DESCRIPTION
I couldn't find a way to easily get the list of parameters for a Job. This pull request adds get_params and get_params_list methods to a Job.
