### PR TITLE
Use preferred URL scheme for jobs

### DIFF
--- a/jenkinsapi/jenkins.py
+++ b/jenkinsapi/jenkins.py
@@ -318,7 +318,10 @@ class Jenkins(JenkinsBase):
         """
         for url, name in self.get_jobs_info():
             if name == jobname:
-                return Job(url, name, jenkins_obj=self)
+                preferred_scheme = urlparse.urlsplit(self.baseurl).scheme
+                url_split = urlparse.urlsplit(url)
+                preffered_url = urlparse.urlunsplit([preferred_scheme, url_split.netloc, url_split.path, url_split.query, url_split.fragment])
+                return Job(preferred_url, name, jenkins_obj=self)
         raise UnknownJob(jobname)
 
     def get_node_dict(self):


### PR DESCRIPTION
Some Jenkins instances are configured to allow reading the data over HTTP scheme, while for manipulating with data (e.g. creating or deleting a job) HTTPS scheme is required. Allow user to specify preferred URL scheme (by specifying Jenkins URL) and use this scheme also manipulations with jobs.
