### PR TITLE
Changed View.add_job() to actually add job to the view, rather than replace all jobs in the view by that job.

### DIFF
--- a/jenkinsapi/view.py
+++ b/jenkinsapi/view.py
@@ -62,6 +62,10 @@ class View(JenkinsBase):
         elif not self.get_jenkins_obj().has_job(str_job_name):
             return "Job %s is not known - available: %s" % ( str_job_name, ", ".join(self.get_jenkins_obj().get_jobs_list()))
         else:
+            def get_job_url(name):
+                return self.jenkins_obj.get_job(name).baseurl
+            jobs = self._data.setdefault('jobs', [])
+            jobs.append({'name': str_job_name, 'url': get_job_url(str_job_name)})
             data = {
                 "description":"",
                 "statusFilter":"",
@@ -79,7 +83,6 @@ class View(JenkinsBase):
             data["name"] = self.name
             for job in self.get_job_dict().keys():
                 data[job]='on'
-            data[str_job_name] = "on"
             data['json'] = data.copy()
             self.post_data('%sconfigSubmit' % self.baseurl, urllib.urlencode(data))
             return "Job %s is add in View %s successful" % (str_job_name, self.baseurl)


### PR DESCRIPTION
...though it's quite possible that I'm misusing jenkinsapi in some way.

So, I'm trying to put several jobs in view with the following code:

``` python
def put_jobs_into_view(view_url, jobs):
    view_obj = jenkins.get_view_by_url(view_url)
    for job in jobs:
        view_obj.add_job(job.name)
```

After running this code there is only one job in the view -- last one.  And if I try to step through the code with debugger, after each invocation of `.add_obj()` there is only one job in the view, one corresponding current value of `job` variable.

And after applying this commit it works as expected.
