### PR TITLE
Timestamp Fix

### DIFF
--- a/jenkinsapi/build.py
+++ b/jenkinsapi/build.py
@@ -261,7 +261,7 @@ class Build(JenkinsBase):
         return all_actions
 
     def get_timestamp(self):
-        return self._data['timestamp']
+        return (self._data['timestamp'] / 1000)
 
     def stop(self):
         """


### PR DESCRIPTION
The timestamp format from jenkins is in milliseconds but most python
libs that deal with timestamps work in seconds.

If the timestamp value is passed to pythons time.time.ctime() or datetime.datetime.fromtimestamp() it will currently fail because it is expecting seconds not milliseconds.
