### PR TITLE
Fixed bug: view.add_job fails when job parameter contains Job object

### DIFF
--- a/jenkinsapi/view.py
+++ b/jenkinsapi/view.py
@@ -77,7 +77,7 @@ class View(JenkinsBase):
                 log.error('Job "%s" is not known to Jenkins' % str_job_name)
                 return False
 
-        job = self.jenkins_obj.get_job(str_job_name)
+            job = self.jenkins_obj.get_job(str_job_name)
         
         jobs = self._data.setdefault('jobs', [])
         jobs.append({'name': job.name, 'url': job.baseurl})


### PR DESCRIPTION
Found bug in my previous pull request and fixed it. Easy fix, but not covered by unit test yet, I will work on it.
