### PR TITLE
Update jenkins.py

### DIFF
--- a/jenkinsapi/jenkins.py
+++ b/jenkinsapi/jenkins.py
@@ -154,7 +154,7 @@ class Jenkins(JenkinsBase):
         :param params: the job params, dict
         :return: none
         """
-        self[jobname].invoke(params=params)
+        self[jobname].invoke(build_params=params)
         return
 
     def delete_job(self, jobname):


### PR DESCRIPTION
I found a bug in the build_job function, self[jobname].invoke(params=params) should have "build_params" instead of "params" ,i.e. self[jobname].invoke(build_params=params)

Not sure where else this function is being used through out the api library,but the issue could be in other places.

Hope that helps,
S.A.
