### PR TITLE
Fix Build.get_revision() for git repositories

### DIFF
--- a/jenkinsapi/build.py
+++ b/jenkinsapi/build.py
@@ -53,11 +53,13 @@ class Build(JenkinsBase):
         return maxRevision
 
     def _get_git_rev(self):
-        for item in self._data['actions']:
-            branch = item.get('buildsByBranchName')
-            head = branch and branch.get('origin/HEAD')
-            if head:
-                return head['revision']['SHA1']
+        # Sometimes we have None as part of actions. Filter those actions
+        # which have lastBuiltRevision in them
+        _actions = [x for x in self._data['actions'] if x \
+                        and "lastBuiltRevision" in x]
+        for item in _actions:
+            revision = item["lastBuiltRevision"]["SHA1"]
+            return revision
 
     def _get_hg_rev(self):
         return [x['mercurialNodeName'] for x in self._data['actions'] if 'mercurialNodeName' in x][0]


### PR DESCRIPTION
With Jenkins, 1.5xx `Build.get_revision` is failing with the following error,

```
In [26]: b.get_revision()
---------------------------------------------------------------------------
AttributeError                            
Traceback (most recent call last)
<ipython-input-26-aac64a6bc23a> in <module>()
----> 1 b.get_revision()

/Users/sudharsh/venv/foobar/lib/python2.7/site-packages/jenkinsapi/build.pyc in get_revision(self)
     45     def get_revision(self):
     46         vcs = self._data['changeSet']['kind'] or 'git'
---> 47         return getattr(self, '_get_%s_rev' % vcs, lambda: None)()
     48
     49     def _get_svn_rev(self):

/Users/sudharsh/venv/foobar/lib/python2.7/site-packages/jenkinsapi/build.pyc in _get_git_rev(self)
     55     def _get_git_rev(self):
     56         for item in self._data['actions']:
---> 57             branch = item.get('buildsByBranchName')
     58             head = branch and branch.get('origin/HEAD')
     59             if head:

AttributeError: 'NoneType' object has no attribute 'get'
-----
```

Also, the `branch` was `origin/master` instead of `origin/HEAD` as `_get_git_rev` expects. 

The attached patch removes this dependancy and will work on any remote.
