### PR TITLE
optimize jenkins.get_job to no longer load all job configurations

### DIFF
--- a/jenkinsapi/jenkins.py
+++ b/jenkinsapi/jenkins.py
@@ -93,7 +93,9 @@ class Jenkins(JenkinsBase):
         :param jobname: name of the job, str
         :return: Job obj
         """
-        return self[jobname]
+        for info in self._data["jobs"]:
+            if info["name"] == jobname:
+                return Job(info["url"], info["name"], jenkins_obj=self)
 
     def has_job(self, jobname):
         """


### PR DESCRIPTION
Each time get_job is called, it winds up creating Job objects for every job on the Jenkins server.  In our case, this involves hundreds of unnecessary requests when I'm only interested in one job.  This change removes some of the indirection.  I have not read all of the jenkinsapi code, this was just a hack I threw together to avoid the overhead.  It does not break any unit tests.
