### PR TITLE
Allow no verification of server certificate when using https

### DIFF
--- a/jenkinsapi/jenkins.py
+++ b/jenkinsapi/jenkins.py
@@ -22,20 +22,23 @@ class Jenkins(JenkinsBase):
     """
     Represents a jenkins environment.
     """
-    def __init__(self, baseurl, username=None, password=None, requester=None):
+    def __init__(self, baseurl, username=None, password=None, sslVerify=True, requester=None):
         """
         :param baseurl: baseurl for jenkins instance including port, str
         :param username: username for jenkins auth, str
         :param password: password for jenkins auth, str
+        :param sslVerify: flag if server certificate should be verified or not
         :return: a Jenkins obj
         """
         self.username = username
         self.password = password
-        self.requester = requester or Requester(username, password)
+        self.sslVerify = sslVerify
+        self.requester = requester or Requester(username, password, sslVerify)
         JenkinsBase.__init__(self, baseurl)
 
     def _clone(self):
-        return Jenkins(self.baseurl, username=self.username, password=self.password, requester=self.requester)
+        return Jenkins(self.baseurl, username=self.username, password=self.password, sslVerify=self.sslVerify,
+                       requester=self.requester)
 
     def base_server_url(self):
         if config.JENKINS_API in self.baseurl:
@@ -65,7 +68,7 @@ class Jenkins(JenkinsBase):
         return self
 
     def get_jenkins_obj_from_url(self, url):
-        return Jenkins(url, self.username, self.password, self.requester)
+        return Jenkins(url, self.username, self.password, self.sslVerify, self.requester)
 
     def get_create_url(self):
         # This only ever needs to work on the base object

--- a/jenkinsapi/utils/requester.py
+++ b/jenkinsapi/utils/requester.py
@@ -26,12 +26,13 @@ class Requester(object):
 
     VALID_STATUS_CODES = [200,]
 
-    def __init__(self, username=None, password=None):
+    def __init__(self, username=None, password=None, sslVerify=True):
         if username:
             assert password, 'Cannot set a username without a password!'
 
         self.username = username
         self.password = password
+        self.sslVerify = sslVerify
 
     def get_request_dict(self, url, params, data, headers):
         requestKwargs = {}
@@ -47,6 +48,8 @@ class Requester(object):
             assert isinstance(
                 headers, dict), 'headers must be a dict, got %s' % repr(headers)
             requestKwargs['headers'] = headers
+
+        requestKwargs['verify'] = self.sslVerify
 
         if not data == None:
             # It may seem odd, but some Jenkins operations require posting


### PR DESCRIPTION
It uses stored sslVerify value in every request Requester sends as documented here http://docs.python-requests.org/en/latest/user/advanced/#ssl-cert-verification

It was also added as Jenkins constructor parameter as it is the easiest way how to set that instead of creating special requester.
