### PR TITLE
Use the same protocol in all requests

### DIFF
--- a/jenkinsapi/jenkins.py
+++ b/jenkinsapi/jenkins.py
@@ -33,7 +33,7 @@ class Jenkins(JenkinsBase):
         self.username = username
         self.password = password
         self.sslVerify = sslVerify
-        self.requester = requester or Requester(baseurl, username, password, sslVerify)
+        self.requester = requester or Requester(username, password, baseurl, sslVerify)
         JenkinsBase.__init__(self, baseurl)
 
     def _clone(self):

--- a/jenkinsapi/utils/requester.py
+++ b/jenkinsapi/utils/requester.py
@@ -27,7 +27,7 @@ class Requester(object):
 
     VALID_STATUS_CODES = [200,]
 
-    def __init__(self, baseurl=None, username=None, password=None, sslVerify=True):
+    def __init__(self, username=None, password=None, baseurl=None, sslVerify=True):
         if username:
             assert password, 'Cannot set a username without a password!'
 


### PR DESCRIPTION
Keep the same scheme (protocol) as was used in Jenkins constructor in all requests

Some Jenkins instances are configured to allow reading the data over HTTP scheme and this is also specified in Jenkins configuration in Jenkins root URL, while for manipulating with data (e.g. create or delete job) HTTPS scheme is required. Allow user to specify preferred URL scheme (by specifying Jenkins URL) and use this scheme in all requests.

This feature was introduced in 4f29f6742410736016b568002d8569f19d786841 (version 0.1.13) but lost again in 79934f0b5ca44a1d4ecbaf534eb1add8e343193f.

(This PR follows https://github.com/salimfadhley/jenkinsapi/pull/150 and contains its changes already.)
