### PR TITLE
job can now query Jenkins to load ALL its builds

### DIFF
--- a/jenkinsapi/jenkinsbase.py
+++ b/jenkinsapi/jenkinsbase.py
@@ -52,9 +52,9 @@ class JenkinsBase(object):
         url = self.python_api_url(self.baseurl)
         return self.get_data(url)
 
-    def get_data(self, url):
+    def get_data(self, url, params=None):
         requester = self.get_jenkins_obj().requester
-        response = requester.get_url(url)
+        response = requester.get_url(url, params)
         try:
             return eval(response.text)
         except Exception:

--- a/jenkinsapi/job.py
+++ b/jenkinsapi/job.py
@@ -316,6 +316,15 @@ class Job(JenkinsBase, MutableJenkinsThing):
     def load_config(self):
         self._config = self.get_config()
 
+    def load_all_builds(self):
+        '''Query Jenkins to get all builds of the job.
+
+        Jenkins API loads job data lazily and may not contain all builds
+        information. Call this method to retrieve all builds data.'''
+        api_url = self.python_api_url(self.baseurl)
+        response = self.get_data(api_url, {'tree': 'allBuilds[number,url]'})
+        self._data['builds'] = response['allBuilds']
+
     def get_scm_type(self):
         element_tree = self._get_config_element_tree()
         scm_class = element_tree.find('scm').get('class')


### PR DESCRIPTION
By default, Jenkins API only give the last 100 builds of a job (since this commit : https://github.com/jenkinsci/jenkins/commit/fe9f67 ).

This pull request adds a method Job#load_all_builds. Calling load_all_builds will fetch build number and url of all job builds and store them in job._data['builds'], replacing the previous value and preserving behaviour.
