### PR TITLE
Raise NoBuildData when latestBuild etc. not even set

### DIFF
--- a/jenkinsapi/job.py
+++ b/jenkinsapi/job.py
@@ -159,7 +159,7 @@ class Job(JenkinsBase, MutableJenkinsThing):
             "lastFailedBuild"]
         assert buildtype in KNOWNBUILDTYPES, 'Unknown build info type: %s' % buildtype
 
-        if not self._data[buildtype]:
+        if not self._data.get(buildtype):
             raise NoBuildData(buildtype)
         return self._data[buildtype]["number"]
 

--- a/jenkinsapi_tests/unittests/test_job.py
+++ b/jenkinsapi_tests/unittests/test_job.py
@@ -157,6 +157,14 @@ class TestJob(unittest.TestCase):
         with self.assertRaises(NoBuildData):
             j.get_revision_dict()
 
+    @mock.patch.object(Job, '_poll')
+    def test_nobuilds_get_last_build(self, _poll):
+        # Bare minimum build dict, we only testing dissapearance of 'builds'
+        _poll.return_value = {"name": "foo"}
+
+        j = Job('http://halob:8080/job/foo/', 'foo', self.J)
+        with self.assertRaises(NoBuildData):
+            j.get_last_build()
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The Folders plugin uses jobs as a container for folders.
However, a lot of standard job keys, such as lastBuild et al.
are not even present (unlike a never run job where they are
present but set to None)

Since a value of None for latestBuild causes a NoBuildData
exception, the same exception should be fine when not present.
