### PR TITLE
Add kwargs in jenkins, Requester, api methods

### DIFF
--- a/jenkinsapi/jenkins.py
+++ b/jenkinsapi/jenkins.py
@@ -29,7 +29,7 @@ class Jenkins(JenkinsBase):
     """
     Represents a jenkins environment.
     """
-    def __init__(self, baseurl, username=None, password=None, requester=None):
+    def __init__(self, baseurl, username=None, password=None, requester=None, **kwargs):
         """
         :param baseurl: baseurl for jenkins instance including port, str
         :param username: username for jenkins auth, str
@@ -38,7 +38,7 @@ class Jenkins(JenkinsBase):
         """
         self.username = username
         self.password = password
-        self.requester = requester or Requester(username, password, baseurl=baseurl)
+        self.requester = requester or Requester(username, password, baseurl=baseurl, **kwargs)
         JenkinsBase.__init__(self, baseurl)
 
     def _clone(self):

--- a/jenkinsapi/job.py
+++ b/jenkinsapi/job.py
@@ -573,3 +573,7 @@ class Job(JenkinsBase, MutableJenkinsThing):
         for param in self.get_params():
             params.append(param['name'])
         return params
+
+    def build_iter(self):
+        for build_id in self.get_build_ids():
+            yield self.get_build(build_id)


### PR DESCRIPTION
Also: Add job.build_iter method for iterating over build

his was principally motivated by the need to pass `ssl_verify` through to Requests level because the certificates on my servers are not trusted.
