### PR TITLE
Add optional polling cache to appropriate subclasses of JenkinsBase

### DIFF
--- a/jenkinsapi/build.py
+++ b/jenkinsapi/build.py
@@ -33,11 +33,11 @@ class Build(JenkinsBase):
     STR_TOTALCOUNT = "totalCount"
     STR_TPL_NOTESTS_ERR = "%s has status %s, and does not have any test results"
 
-    def __init__(self, url, buildno, job):
+    def __init__(self, url, buildno, job, poll_cache_timeout=0):
         assert type(buildno) == int
         self.buildno = buildno
         self.job = job
-        JenkinsBase.__init__(self, url)
+        JenkinsBase.__init__(self, url, poll_cache_timeout=poll_cache_timeout)
 
     def _poll(self):
         #For build's we need more information for downstream and upstream builds

--- a/jenkinsapi/jenkins.py
+++ b/jenkinsapi/jenkins.py
@@ -29,7 +29,8 @@ class Jenkins(JenkinsBase):
     """
     Represents a jenkins environment.
     """
-    def __init__(self, baseurl, username=None, password=None, requester=None):
+    def __init__(self, baseurl, username=None, password=None, requester=None,
+                 poll_cache_timeout=0):
         """
         :param baseurl: baseurl for jenkins instance including port, str
         :param username: username for jenkins auth, str
@@ -39,7 +40,8 @@ class Jenkins(JenkinsBase):
         self.username = username
         self.password = password
         self.requester = requester or Requester(username, password, baseurl=baseurl)
-        JenkinsBase.__init__(self, baseurl)
+        JenkinsBase.__init__(self, baseurl,
+                             poll_cache_timeout=poll_cache_timeout)
 
     def _clone(self):
         return Jenkins(self.baseurl, username=self.username,

--- a/jenkinsapi/job.py
+++ b/jenkinsapi/job.py
@@ -38,7 +38,7 @@ class Job(JenkinsBase, MutableJenkinsThing):
     Represents a jenkins job
     A job can hold N builds which are the actual execution environments
     """
-    def __init__(self, url, name, jenkins_obj):
+    def __init__(self, url, name, jenkins_obj, poll_cache_timeout=0):
         self.name = name
         self.jenkins = jenkins_obj
         self._revmap = None
@@ -62,7 +62,7 @@ class Job(JenkinsBase, MutableJenkinsThing):
             'hg': lambda element_tree: list(element_tree.find(HG_BRANCH)),
             None: lambda element_tree: []
         }
-        JenkinsBase.__init__(self, url)
+        JenkinsBase.__init__(self, url, poll_cache_timeout=poll_cache_timeout)
 
     def __str__(self):
         return self._data["name"]

--- a/jenkinsapi/node.py
+++ b/jenkinsapi/node.py
@@ -14,7 +14,7 @@ class Node(JenkinsBase):
     Class to hold information on nodes that are attached as slaves to the master jenkins instance
     """
 
-    def __init__(self, baseurl, nodename, jenkins_obj):
+    def __init__(self, baseurl, nodename, jenkins_obj, poll_cache_timeout=0):
         """
         Init a node object by providing all relevant pointers to it
         :param baseurl: basic url for querying information on a node
@@ -24,7 +24,8 @@ class Node(JenkinsBase):
         """
         self.name = nodename
         self.jenkins = jenkins_obj
-        JenkinsBase.__init__(self, baseurl)
+        JenkinsBase.__init__(self, baseurl,
+                             poll_cache_timeout=poll_cache_timeout)
 
     def get_jenkins_obj(self):
         return self.jenkins

--- a/jenkinsapi/nodes.py
+++ b/jenkinsapi/nodes.py
@@ -15,12 +15,13 @@ class Nodes(JenkinsBase):
     Class to hold information on a collection of nodes
     """
 
-    def __init__(self, baseurl, jenkins_obj):
+    def __init__(self, baseurl, jenkins_obj, poll_cache_timeout=0):
         """
         Handy access to all of the nodes on your Jenkins server
         """
         self.jenkins = jenkins_obj
-        JenkinsBase.__init__(self, baseurl)
+        JenkinsBase.__init__(self, baseurl,
+                             poll_cache_timeout=poll_cache_timeout)
 
     def get_jenkins_obj(self):
         return self.jenkins

--- a/jenkinsapi/plugins.py
+++ b/jenkinsapi/plugins.py
@@ -15,9 +15,9 @@ class Plugins(JenkinsBase):
     """
     Plugins class for jenkinsapi
     """
-    def __init__(self, url, jenkins_obj):
+    def __init__(self, url, jenkins_obj, poll_cache_timeout=0):
         self.jenkins_obj = jenkins_obj
-        JenkinsBase.__init__(self, url)
+        JenkinsBase.__init__(self, url, poll_cache_timeout=poll_cache_timeout)
         # print 'DEBUG: Plugins._data=', self._data
 
     def get_jenkins_obj(self):

--- a/jenkinsapi/queue.py
+++ b/jenkinsapi/queue.py
@@ -14,14 +14,15 @@ class Queue(JenkinsBase):
     Class that represents the Jenkins queue
     """
 
-    def __init__(self, baseurl, jenkins_obj):
+    def __init__(self, baseurl, jenkins_obj, poll_cache_timeout=0):
         """
         Init the Jenkins queue object
         :param baseurl: basic url for the queue
         :param jenkins_obj: ref to the jenkins obj
         """
         self.jenkins = jenkins_obj
-        JenkinsBase.__init__(self, baseurl)
+        JenkinsBase.__init__(self, baseurl,
+                             poll_cache_timeout=poll_cache_timeout)
 
     def __str__(self):
         return self.baseurl

--- a/jenkinsapi/result_set.py
+++ b/jenkinsapi/result_set.py
@@ -10,14 +10,14 @@ class ResultSet(JenkinsBase):
     """
     Represents a result from a completed Jenkins run.
     """
-    def __init__(self, url, build):
+    def __init__(self, url, build, poll_cache_timeout=0):
         """
         Init a resultset
         :param url: url for a build, str
         :param build: build obj
         """
         self.build = build
-        JenkinsBase.__init__(self, url)
+        JenkinsBase.__init__(self, url, poll_cache_timeout=poll_cache_timeout)
 
     def get_jenkins_obj(self):
         return self.build.job.get_jenkins_obj()

--- a/jenkinsapi/view.py
+++ b/jenkinsapi/view.py
@@ -16,10 +16,10 @@ class View(JenkinsBase):
     View class
     """
 
-    def __init__(self, url, name, jenkins_obj):
+    def __init__(self, url, name, jenkins_obj, poll_cache_timeout=0):
         self.name = name
         self.jenkins_obj = jenkins_obj
-        JenkinsBase.__init__(self, url)
+        JenkinsBase.__init__(self, url, poll_cache_timeout=poll_cache_timeout)
         self.deleted = False
 
     def __str__(self):

--- a/jenkinsapi_tests/unittests/test_jenkinsbase.py
+++ b/jenkinsapi_tests/unittests/test_jenkinsbase.py
@@ -3,3 +3,5 @@ class TestJenkinsBaseMixin(object):
     Tests which apply to all or most Jenkins objects
     """
     pass
+
+

--- a/jenkinsapi_tests/unittests/test_node.py
+++ b/jenkinsapi_tests/unittests/test_node.py
@@ -1,5 +1,6 @@
 import mock
 import unittest
+import time
 
 from jenkinsapi.node import Node
 
@@ -52,6 +53,26 @@ class TestNode(unittest.TestCase):
     def test_online(self, _poll):
         _poll.return_value = self.DATA
         return self.assertEquals(self.n.is_online(), True)
+
+    @mock.patch.object(Node, '_poll')
+    def test_poll_cache(self, _poll):
+        # only gets called once in interval
+        n = Node('http://', 'bobnit', self.J, poll_cache_timeout=1)
+        for i in range(2):
+            n.poll()
+        self.assertEquals(_poll.call_count, 1)
+
+        # ensure it gets called again after cache timeout
+        _poll.reset_mock()
+        time.sleep(1)
+        n.poll()
+        self.assertTrue(_poll.called)
+
+        # ensure it is disabled by default
+        _poll.reset_mock()
+        for i in range(2):
+            self.n.poll()
+        self.assertEquals(_poll.call_count, 2)
 
 if __name__ == '__main__':
     unittest.main()

--- a/jenkinsapi_tests/unittests/test_nodes.py
+++ b/jenkinsapi_tests/unittests/test_nodes.py
@@ -1,5 +1,6 @@
 import mock
 import unittest
+import time
 
 from jenkinsapi.jenkins import Jenkins
 from jenkinsapi.nodes import Nodes
@@ -221,6 +222,26 @@ class TestNode(unittest.TestCase):
         _poll_node.return_value = self.DATA3
         mn = self.ns['halob']
         self.assertIsInstance(mn, Node)
+
+    @mock.patch.object(Nodes, '_poll')
+    def test_poll_cache(self, _poll):
+        # only gets called once in interval
+        ns = Nodes('http://', self.J, poll_cache_timeout=1)
+        for i in range(2):
+            ns.poll()
+        self.assertEquals(_poll.call_count, 1)
+
+        # ensure it gets called again after cache timeout
+        _poll.reset_mock()
+        time.sleep(1)
+        ns.poll()
+        self.assertTrue(_poll.called)
+
+        # ensure it is disabled by default
+        _poll.reset_mock()
+        for i in range(2):
+            self.ns.poll()
+        self.assertEquals(_poll.call_count, 2)
 
 if __name__ == '__main__':
     unittest.main()

--- a/jenkinsapi_tests/unittests/test_plugins.py
+++ b/jenkinsapi_tests/unittests/test_plugins.py
@@ -1,5 +1,6 @@
 import mock
 import unittest
+import time
 
 from jenkinsapi.jenkins import Jenkins
 from jenkinsapi.plugins import Plugins
@@ -152,6 +153,27 @@ class TestPlugins(unittest.TestCase):
 
         plugin = self.J.get_plugins()['subversion']
         self.assertEquals(p, plugin)
+
+    @mock.patch.object(Plugins, '_poll')
+    def test_poll_cache(self, _poll):
+        # only gets called once in interval
+        plugins = Plugins('http://', self.J, poll_cache_timeout=1)
+        for i in range(2):
+            plugins.poll()
+        self.assertEquals(_poll.call_count, 1)
+
+        # ensure it gets called again after cache timeout
+        _poll.reset_mock()
+        time.sleep(1)
+        plugins.poll()
+        self.assertTrue(_poll.called)
+
+        # ensure it is disabled by default
+        _poll.reset_mock()
+        plugins = self.J.get_plugins()
+        for i in range(2):
+            plugins.poll()
+        self.assertEquals(_poll.call_count, 3)  # get plugins triggers a poll
 
 if __name__ == '__main__':
     unittest.main()

--- a/jenkinsapi_tests/unittests/test_queue.py
+++ b/jenkinsapi_tests/unittests/test_queue.py
@@ -1,5 +1,6 @@
 import mock
 import unittest
+import time
 
 from jenkinsapi import config
 from jenkinsapi.jenkins import Jenkins
@@ -142,6 +143,26 @@ class TestQueue(unittest.TestCase):
         item40 = self.q[40]
         j = item40.get_job()
         self.assertIsInstance(j, Job)
+
+    @mock.patch.object(Queue, '_poll')
+    def test_poll_cache(self, _poll):
+        # only gets called once in interval
+        q = Queue('http://localhost:8080/queue', self.J, poll_cache_timeout=1)
+        for i in range(2):
+            q.poll()
+        self.assertEquals(_poll.call_count, 1)
+
+        # ensure it gets called again after cache timeout
+        _poll.reset_mock()
+        time.sleep(1)
+        q.poll()
+        self.assertTrue(_poll.called)
+
+        # ensure it is disabled by default
+        _poll.reset_mock()
+        for i in range(2):
+            self.q.poll()
+        self.assertEquals(_poll.call_count, 2)
 
 if __name__ == '__main__':
     unittest.main()

--- a/jenkinsapi_tests/unittests/test_view.py
+++ b/jenkinsapi_tests/unittests/test_view.py
@@ -1,5 +1,6 @@
 import mock
 import unittest
+import time
 
 from jenkinsapi.jenkinsbase import JenkinsBase
 from jenkinsapi.jenkins import Jenkins
@@ -149,6 +150,28 @@ class TestView(unittest.TestCase):
         result = self.v.get_nested_view_dict()
         self.assertTrue(isinstance(result, dict))
         self.assertEquals(len(result), 0)
+
+    @mock.patch.object(View, '_poll')
+    def test_poll_cache(self, _poll):
+        # only gets called once in interval
+        v = View('http://localhost:800/view/FodFanFo', 'FodFanFo', self.J,
+                  poll_cache_timeout=1)
+        for i in range(2):
+            v.poll()
+        self.assertEquals(_poll.call_count, 1)
+
+        # ensure it gets called again after cache timeout
+        _poll.reset_mock()
+        time.sleep(1)
+        v.poll()
+        self.assertTrue(_poll.called)
+
+        # ensure it is disabled by default
+        _poll.reset_mock()
+        for i in range(2):
+            self.v.poll()
+        self.assertEquals(_poll.call_count, 2)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I added an optional `poll_cache_timeout` parameter to subclasses of `JenkinsBase` because I noticed in certain circumstances the api polls the Jenkins server excessively. For example, I noticed when querying whether a Job is queued or running, the following code results in 6 http requests, when only 2 are unique:

```
job = Job(job_url, job_name, jenkins_obj)
busy = job.is_queued_or_running()
```

To prevent this, I modified the `poll` method to skip calling `_poll` if it has already been called in the last `poll_cache_timeout` seconds. By default, the cache is disabled, so it will not modify current behavior.
