### PR TITLE
Randomize jenkins http port for systests #181

### DIFF
--- a/jenkinsapi_tests/systests/base.py
+++ b/jenkinsapi_tests/systests/base.py
@@ -1,4 +1,5 @@
 import unittest
+import jenkinsapi_tests.systests
 from jenkinsapi_tests.systests.job_configs import EMPTY_JOB
 from jenkinsapi.jenkins import Jenkins
 
@@ -6,7 +7,8 @@ from jenkinsapi.jenkins import Jenkins
 class BaseSystemTest(unittest.TestCase):
 
     def setUp(self):
-        self.jenkins = Jenkins('http://localhost:8080')
+        port = jenkinsapi_tests.systests.state['launcher'].http_port
+        self.jenkins = Jenkins('http://localhost:%d' % port)
         self._delete_all_jobs()
         self._delete_all_views()
 

--- a/jenkinsapi_utils/jenkins_launcher.py
+++ b/jenkinsapi_utils/jenkins_launcher.py
@@ -1,6 +1,7 @@
 import os
 import time
 import Queue
+import random
 import shutil
 import logging
 import datetime
@@ -60,6 +61,7 @@ class JenkinsLancher(object):
         self.jenkins_process = None
         self.q = Queue.Queue()
         self.plugin_urls = plugin_urls or []
+        self.http_port = random.randint(9000, 10000)
 
     def update_war(self):
         os.chdir(self.war_directory)
@@ -121,7 +123,8 @@ class JenkinsLancher(object):
         os.environ['JENKINS_HOME'] = self.jenkins_home
         os.chdir(self.war_directory)
 
-        jenkins_command = ['java', '-jar', self.war_filename]
+        jenkins_command = ['java', '-jar', self.war_filename, 
+            '--httpPort=%d' % self.http_port]
 
         log.info("About to start Jenkins...")
         log.info("%s> %s", os.getcwd(), " ".join(jenkins_command))


### PR DESCRIPTION
This commit adds an http_port variable to JenkinsLaunch which is randomly assigned a number between 9000 and 10000. This variable is then used when starting jenkins.war and during setup of the BaseSystemTest class.
