### PR TITLE
error "Problem accessing /queue/api/python" when attempting parameterized build on jenkins server using prefix / context path

### DIFF
--- a/jenkinsapi/jenkins.py
+++ b/jenkinsapi/jenkins.py
@@ -225,7 +225,7 @@ class Jenkins(JenkinsBase):
         return url
 
     def get_queue_url(self):
-        url = urlparse.urljoin(self.base_server_url(), 'queue')
+        url = "%s/%s" % (self.base_server_url(), 'queue')
         return url
 
     def get_queue(self):


### PR DESCRIPTION
I was attempting a parameterized job build on a jenkins server setup using a prefix. For instance the url is "http://address:8080/jenkins". I received the following error from jenkins which was also confirmed by a customer:

```
<head>
<meta http-equiv="Content-Type" content="text/html;charset=ISO-8859-1"/>
<title>Error 404 Not Found</title>
</head>
<body>
<h2>HTTP ERROR: 404</h2>
<p>Problem accessing /queue/api/python. Reason:
<pre>    Not Found</pre></p>
<hr /><i><small>Powered by Jetty://</small></i>
</body>
</html>
```

The get_queue_url method in jenkins.py is using urlparse.urljoin which strips the context path off of the base_server_url. In this case it was stripping /jenkins off. 

To replicate, setup a jenkins server and set JENKINS_ARGS="--prefix=/jenkins" and restart the server. Setup a project named "test" with a single build parameter, then run the following script before and after the patch. Note this script does not take auth into account. 

```
from jenkinsapi.jenkins import Jenkins

def test():
    j = Jenkins('http://myserver:8080/jenkins')
    params = {}
    params["BUILD"] = "xyz"
    i = j['test'].invoke(build_params=params)

test()
```

One thing to note, there are other places where urlparse.urljoin() are used which may be affected by the content path / prefix. I did not test or touch those. 
