### PR TITLE
swicth from /python urls to /json urls to support Hudson

### DIFF
--- a/jenkinsapi/config.py
+++ b/jenkinsapi/config.py
@@ -3,6 +3,6 @@ Jenkins configuration
 """
 
 
-JENKINS_API = r"api/python"
+JENKINS_API = r"api/json"
 
 LOAD_TIMEOUT = 30

--- a/jenkinsapi/jenkinsbase.py
+++ b/jenkinsapi/jenkinsbase.py
@@ -2,10 +2,15 @@
 Module for JenkinsBase class
 """
 
-import ast
 import logging
 from jenkinsapi import config
 from jenkinsapi.custom_exceptions import JenkinsAPIException
+
+try:
+    import json
+except ImportError:
+    import simplejson as json
+
 log = logging.getLogger(__name__)
 
 
@@ -62,7 +67,7 @@ class JenkinsBase(object):
         requester = self.get_jenkins_obj().requester
         response = requester.get_url(url, params)
         try:
-            return ast.literal_eval(response.text)
+            return json.loads(response.text)
         except Exception:
             log.exception('Inappropriate content found at %s', url)
             raise JenkinsAPIException('Cannot parse %s' % response.content)


### PR DESCRIPTION
This patch will switch to using the pure json urls instead of jenkins python friendly json variant. As far as I know the only difference is the representation of booleans. 

This restores Hudson support as the later Hudson versions have removed the python urls.
