### PR TITLE
Hudson compatible and support for Hudson Team Concept.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .settings
 *.DS_Store
 jenkins.war
+hudson.war
 .coverage/
 .coverage
 nosetests.xml

--- a/jenkinsapi/config.py
+++ b/jenkinsapi/config.py
@@ -3,6 +3,6 @@ Jenkins configuration
 """
 
 
-JENKINS_API = r"api/python"
+JENKINS_API = r"api/json"
 
 LOAD_TIMEOUT = 30

--- a/jenkinsapi/jenkins.py
+++ b/jenkinsapi/jenkins.py
@@ -120,14 +120,14 @@ class Jenkins(JenkinsBase):
         """
         return jobname in self.jobs
 
-    def create_job(self, jobname, config_):
+    def create_job(self, jobname, config_, team=None):
         """
         Create a job
         :param jobname: name of new job, str
         :param config: configuration of new job, xml
         :return: new Job obj
         """
-        return self.jobs.create(jobname, config_)
+        return self.jobs.create(jobname, config_, team)
 
     def copy_job(self, jobname, newjobname):
         return self.jobs.copy(jobname, newjobname)

--- a/jenkinsapi/jenkinsbase.py
+++ b/jenkinsapi/jenkinsbase.py
@@ -2,10 +2,15 @@
 Module for JenkinsBase class
 """
 
-import ast
 import logging
 from jenkinsapi import config
 from jenkinsapi.custom_exceptions import JenkinsAPIException
+
+try:
+    import json
+except ImportError:
+    import simplejson as json
+
 log = logging.getLogger(__name__)
 
 
@@ -62,7 +67,7 @@ class JenkinsBase(object):
         requester = self.get_jenkins_obj().requester
         response = requester.get_url(url, params)
         try:
-            return ast.literal_eval(response.text)
+            return json.loads(response.text, object_hook=self._decode_dict)
         except Exception:
             log.exception('Inappropriate content found at %s', url)
             raise JenkinsAPIException('Cannot parse %s' % response.content)
@@ -77,3 +82,29 @@ class JenkinsBase(object):
             else:
                 fmt = "%s/%s"
             return fmt % (url, config.JENKINS_API)
+
+    def _decode_list(self, data):
+        rv = []
+        for item in data:
+            if isinstance(item, unicode):
+                item = item.encode('utf-8')
+            elif isinstance(item, list):
+                item = self._decode_list(item)
+            elif isinstance(item, dict):
+                item = self._decode_dict(item)
+            rv.append(item)
+        return rv
+
+    def _decode_dict(self, data):
+        rv = {}
+        for key, value in data.iteritems():
+            if isinstance(key, unicode):
+                key = key.encode('utf-8')
+            if isinstance(value, unicode):
+                value = value.encode('utf-8')
+            elif isinstance(value, list):
+                value = self._decode_list(value)
+            elif isinstance(value, dict):
+                value = self._decode_dict(value)
+            rv[key] = value
+        return rv

--- a/jenkinsapi/jobs.py
+++ b/jenkinsapi/jobs.py
@@ -78,17 +78,26 @@ class Jobs(object):
         """
         return list(self.iterkeys())
 
-    def create(self, job_name, config):
+    def create(self, job_name, config, team=None):
         """
         Create a job
         :param jobname: name of new job, str
         :param config: configuration of new job, xml
+        :param team optional team for Hudson team concept
         :return: new Job obj
         """
-        if job_name in self:
-            return self[job_name]
 
+        full_job_name = job_name
         params = {'name': job_name}
+
+        # if team is provided we need to add a parameter and the jobname AFTER creation will be <team>.<jobname>
+        if team:
+            params = {'name': job_name, "team": team}
+            full_job_name = team + "." + job_name
+
+        if full_job_name in self:
+            return self[full_job_name]
+
         if isinstance(config, unicode):
             config = str(config)
         self.jenkins.requester.post_xml_and_confirm_status(
@@ -97,10 +106,10 @@ class Jobs(object):
             params=params
         )
         self.jenkins.poll()
-        if job_name not in self:
-            raise JenkinsAPIException('Cannot create job %s' % job_name)
+        if full_job_name not in self:
+            raise JenkinsAPIException('Cannot create job %s' % full_job_name)
 
-        return self[job_name]
+        return self[full_job_name]
 
     def copy(self, job_name, new_job_name):
         """

--- a/jenkinsapi_tests/hudsontests/__init__.py
+++ b/jenkinsapi_tests/hudsontests/__init__.py
@@ -1,0 +1,23 @@
+import os
+from jenkinsapi_utils.jenkins_launcher import JenkinsLancher
+from jenkinsapi_utils.hudson_launcher import HudsonLancher
+
+state = {}
+
+# Extra plugins required by the hudson tests
+PLUGIN_DEPENDENCIES = ["http://hudson-ci.org/update-center3/downloads/plugins/birt-charts/3.0.3/birt-charts.hpi",
+                       "http://hudson-ci.org/update-center3/downloads/plugins/jna-native-support-plugin/3.0.4/jna-native-support-plugin.hpi",
+                       "http://hudson-ci.org/update-center3/downloads/plugins/xpath-provider/1.0.2/xpath-provider.hpi"]
+
+
+def setUpPackage():
+    hudsontests_dir, _ = os.path.split(__file__)
+
+    hudson_war_path = os.path.join(hudsontests_dir, 'hudson.war')
+    state['launcher'] = HudsonLancher(hudson_war_path, PLUGIN_DEPENDENCIES)
+    print "Starting"
+    state['launcher'].start()
+
+
+def tearDownPackage():
+    state['launcher'].stop()

--- a/jenkinsapi_tests/hudsontests/admin-user.xml
+++ b/jenkinsapi_tests/hudsontests/admin-user.xml
@@ -1,0 +1,23 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<user>
+  <fullName>admin</fullName>
+  <properties>
+    <hudson.model.MyViewsProperty>
+      <primaryViewName>All</primaryViewName>
+      <views>
+        <hudson.model.AllView>
+          <owner class="hudson.model.MyViewsProperty" reference="../../.."/>
+          <name>All</name>
+          <filterExecutors>false</filterExecutors>
+          <filterQueue>false</filterQueue>
+        </hudson.model.AllView>
+      </views>
+    </hudson.model.MyViewsProperty>
+    <hudson.security.HudsonPrivateSecurityRealm_-Details>
+      <passwordHash>mLcAFg:83bf0fc63480d1a87c9311f946ff6c7f36d2242dbcb460e2471be58900c62f5f</passwordHash>
+    </hudson.security.HudsonPrivateSecurityRealm_-Details>
+    <hudson.tasks.Mailer_-UserProperty>
+      <emailAddress>admin@example.com</emailAddress>
+    </hudson.tasks.Mailer_-UserProperty>
+  </properties>
+</user>

--- a/jenkinsapi_tests/hudsontests/base.py
+++ b/jenkinsapi_tests/hudsontests/base.py
@@ -1,0 +1,42 @@
+import unittest
+import jenkinsapi_tests.systests
+from jenkinsapi_tests.systests.job_configs import EMPTY_JOB
+from jenkinsapi.jenkins import Jenkins
+
+
+class BaseSystemTest(unittest.TestCase):
+
+    def setUp(self):
+        port = jenkinsapi_tests.hudsontests.state['launcher'].http_port
+        print "Hudson started"
+        self.hudson = Jenkins('http://localhost:%d' % port, "admin", "admin")
+        self._delete_all_jobs()
+        self._delete_all_views()
+
+    def tearDown(self):
+        pass
+
+    def _delete_all_jobs(self):
+        self.hudson.poll()
+        for name in self.hudson.get_jobs_list():
+            self.hudson.delete_job(name)
+
+    def _delete_all_views(self):
+        all_view_names = self.hudson.views.keys()[1:]
+        for name in all_view_names:
+            del self.hudson.views[name]
+
+    def _create_job(self, name='whatever', config=EMPTY_JOB):
+        job = self.hudson.create_job(name, config)
+        self.hudson.poll()
+        return job
+
+    def assertJobIsPresent(self, name):
+        self.hudson.poll()
+        self.assertTrue(name in self.hudson,
+                        'Job %r is absent in Hudson.' % name)
+
+    def assertJobIsAbsent(self, name):
+        self.hudson.poll()
+        self.assertTrue(name not in self.hudson,
+                        'Job %r is present in Hudson.' % name)

--- a/jenkinsapi_tests/hudsontests/config.xml
+++ b/jenkinsapi_tests/hudsontests/config.xml
@@ -1,0 +1,30 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<hudson>
+  <version>3.1.0</version>
+  <numExecutors>2</numExecutors>
+  <mode>NORMAL</mode>
+  <privacyMessage></privacyMessage>
+  <instanceTag>private</instanceTag>
+  <jdks/>
+  <viewsTabBar class="hudson.views.DefaultViewsTabBar"/>
+  <myViewsTabBar class="hudson.views.DefaultMyViewsTabBar"/>
+  <clouds/>
+  <slaves/>
+  <quietPeriod>5</quietPeriod>
+  <scmCheckoutRetryCount>0</scmCheckoutRetryCount>
+  <views>
+    <hudson.model.AllView>
+      <owner class="hudson" reference="../../.."/>
+      <name>All</name>
+      <filterExecutors>false</filterExecutors>
+      <filterQueue>false</filterQueue>
+    </hudson.model.AllView>
+  </views>
+  <primaryView>All</primaryView>
+  <slaveAgentPort>0</slaveAgentPort>
+  <label></label>
+  <nodeProperties/>
+  <globalNodeProperties/>
+  <disabledAdministrativeMonitors/>
+  <useBlueBall>false</useBlueBall>
+</hudson>

--- a/jenkinsapi_tests/hudsontests/get-hudson-war.sh
+++ b/jenkinsapi_tests/hudsontests/get-hudson-war.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+HUDSON_WAR_URL="http://eclipse.org/downloads/download.php?file=/hudson/war/hudson-3.1.0.war&r=1"
+wget $HUDSON_WAR_URL --output-document hudson.war

--- a/jenkinsapi_tests/hudsontests/initSetup.xml
+++ b/jenkinsapi_tests/hudsontests/initSetup.xml
@@ -1,0 +1,2 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<string>Hudson 3.0 Initial Setup Done</string>

--- a/jenkinsapi_tests/hudsontests/job_configs.py
+++ b/jenkinsapi_tests/hudsontests/job_configs.py
@@ -1,0 +1,272 @@
+"""
+A selection of job objects used in testing.
+"""
+
+EMPTY_JOB = '''\
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description></description>
+  <keepDependencies>false</keepDependencies>
+  <properties/>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers class="vector"/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders/>
+  <publishers/>
+  <buildWrappers/>
+</project>
+'''.strip()
+
+LONG_RUNNING_JOB = """
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description></description>
+  <keepDependencies>false</keepDependencies>
+  <properties/>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers class="vector"/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>ping -c 200 localhost</command>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers/>
+  <buildWrappers/>
+</project>""".strip()
+
+SHORTISH_JOB = """
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description></description>
+  <keepDependencies>false</keepDependencies>
+  <properties/>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers class="vector"/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>ping -c 10 localhost</command>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers/>
+  <buildWrappers/>
+</project>""".strip()
+
+
+SCM_GIT_JOB = """
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description></description>
+  <keepDependencies>false</keepDependencies>
+  <properties/>
+  <scm class="hudson.plugins.git.GitSCM">
+    <configVersion>2</configVersion>
+    <userRemoteConfigs>
+      <hudson.plugins.git.UserRemoteConfig>
+        <name></name>
+        <refspec></refspec>
+        <url>https://github.com/salimfadhley/jenkinsapi.git</url>
+      </hudson.plugins.git.UserRemoteConfig>
+    </userRemoteConfigs>
+    <branches>
+      <hudson.plugins.git.BranchSpec>
+        <name>**</name>
+      </hudson.plugins.git.BranchSpec>
+    </branches>
+    <disableSubmodules>false</disableSubmodules>
+    <recursiveSubmodules>false</recursiveSubmodules>
+    <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
+    <authorOrCommitter>false</authorOrCommitter>
+    <clean>false</clean>
+    <wipeOutWorkspace>false</wipeOutWorkspace>
+    <pruneBranches>false</pruneBranches>
+    <remotePoll>false</remotePoll>
+    <ignoreNotifyCommit>false</ignoreNotifyCommit>
+    <useShallowClone>false</useShallowClone>
+    <buildChooser class="hudson.plugins.git.util.DefaultBuildChooser"/>
+    <gitTool>Default</gitTool>
+    <submoduleCfg class="list"/>
+    <relativeTargetDir></relativeTargetDir>
+    <reference></reference>
+    <excludedRegions></excludedRegions>
+    <excludedUsers></excludedUsers>
+    <gitConfigName></gitConfigName>
+    <gitConfigEmail></gitConfigEmail>
+    <skipTag>true</skipTag>
+    <includedRegions></includedRegions>
+    <scmName></scmName>
+  </scm>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers class="vector"/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders/>
+  <publishers/>
+  <buildWrappers/>
+</project>""".strip()
+
+JOB_WITH_ARTIFACTS = """
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description>Ping a load of stuff for about 10s</description>
+  <keepDependencies>false</keepDependencies>
+  <properties/>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers class="vector"/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>ping -c 5 localhost | tee out.txt
+gzip &lt; out.txt &gt; out.gz</command>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers>
+    <hudson.tasks.ArtifactArchiver>
+      <artifacts>*.txt,*.gz</artifacts>
+      <latestOnly>false</latestOnly>
+    </hudson.tasks.ArtifactArchiver>
+    <hudson.tasks.Fingerprinter>
+      <targets></targets>
+      <recordBuildArtifacts>true</recordBuildArtifacts>
+    </hudson.tasks.Fingerprinter>
+  </publishers>
+  <buildWrappers/>
+</project>""".strip()
+
+MATRIX_JOB = """
+<?xml version='1.0' encoding='UTF-8'?>
+<matrix-project>
+  <actions/>
+  <description></description>
+  <keepDependencies>false</keepDependencies>
+  <properties/>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers class="vector"/>
+  <concurrentBuild>false</concurrentBuild>
+  <axes>
+    <hudson.matrix.TextAxis>
+      <name>foo</name>
+      <values>
+        <string>one</string>
+        <string>two</string>
+        <string>three</string>
+      </values>
+    </hudson.matrix.TextAxis>
+  </axes>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>ping -c 10 localhost</command>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers/>
+  <buildWrappers/>
+</matrix-project>""".strip()
+
+JOB_WITH_FILE = """
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description></description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.FileParameterDefinition>
+          <name>file.txt</name>
+          <description></description>
+        </hudson.model.FileParameterDefinition>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>cat file.txt</command>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers>
+    <hudson.tasks.ArtifactArchiver>
+      <artifacts>*</artifacts>
+      <latestOnly>false</latestOnly>
+    </hudson.tasks.ArtifactArchiver>
+  </publishers>
+  <buildWrappers/>
+</project>""".strip()
+
+JOB_WITH_PARAMETERS = """
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description>A build that explores the wonderous possibilities of parameterized builds.</description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <hudson.model.ParametersDefinitionProperty>
+      <parameterDefinitions>
+        <hudson.model.StringParameterDefinition>
+          <name>B</name>
+          <description>B, like buzzing B.</description>
+          <defaultValue></defaultValue>
+        </hudson.model.StringParameterDefinition>
+      </parameterDefinitions>
+    </hudson.model.ParametersDefinitionProperty>
+  </properties>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers class="vector"/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>ping -c 1 localhost | tee out.txt
+echo $A &gt; a.txt
+echo $B &gt; b.txt</command>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers>
+    <hudson.tasks.ArtifactArchiver>
+      <artifacts>*</artifacts>
+      <latestOnly>false</latestOnly>
+    </hudson.tasks.ArtifactArchiver>
+    <hudson.tasks.Fingerprinter>
+      <targets></targets>
+      <recordBuildArtifacts>true</recordBuildArtifacts>
+    </hudson.tasks.Fingerprinter>
+  </publishers>
+  <buildWrappers/>
+</project>""".strip()

--- a/jenkinsapi_tests/hudsontests/security.xml
+++ b/jenkinsapi_tests/hudsontests/security.xml
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<hudsonSecurityManager>
+  <securityRealm class="hudson.security.HudsonPrivateSecurityRealm">
+    <disableSignup>false</disableSignup>
+    <enableCaptcha>false</enableCaptcha>
+    <notifyUser>true</notifyUser>
+  </securityRealm>
+  <authorizationStrategy class="org.eclipse.hudson.security.team.TeamBasedAuthorizationStrategy"/>
+  <useSecurity>true</useSecurity>
+  <markupFormatter class="hudson.markup.RawHtmlMarkupFormatter"/>
+</hudsonSecurityManager>

--- a/jenkinsapi_tests/hudsontests/teams.xml
+++ b/jenkinsapi_tests/hudsontests/teams.xml
@@ -1,0 +1,15 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<teamManager>
+  <sysAdmin>admin</sysAdmin>
+  <team>
+    <name>one</name>
+    <description>team one</description>
+  </team>
+  <team>
+    <name>two</name>
+    <description>team two</description>
+  </team>
+  <team>
+    <name>public</name>
+  </team>
+</teamManager>

--- a/jenkinsapi_tests/hudsontests/test_invocation.py
+++ b/jenkinsapi_tests/hudsontests/test_invocation.py
@@ -1,0 +1,77 @@
+'''
+System tests for `jenkinsapi.jenkins` module.
+'''
+import unittest
+import time
+from jenkinsapi.build import Build
+from jenkinsapi.invocation import Invocation
+from jenkinsapi_tests.hudsontests.base import BaseSystemTest
+from jenkinsapi_tests.test_utils.random_strings import random_string
+from jenkinsapi_tests.hudsontests.job_configs import LONG_RUNNING_JOB
+from jenkinsapi_tests.hudsontests.job_configs import SHORTISH_JOB, EMPTY_JOB
+
+
+class TestInvocation(BaseSystemTest):
+
+    def test_invocation_object(self):
+        job_name = 'create_%s' % random_string()
+        job = self.hudson.create_job(job_name, LONG_RUNNING_JOB)
+        ii = job.invoke(invoke_pre_check_delay=7)
+        self.assertIsInstance(ii, Invocation)
+        # Let hudson catchup
+        time.sleep(3)
+        self.assertTrue(ii.is_queued_or_running())
+        self.assertEquals(ii.get_build_number(), 1)
+
+    def test_get_block_until_build_running(self):
+        job_name = 'create_%s' % random_string()
+        job = self.hudson.create_job(job_name, LONG_RUNNING_JOB)
+        ii = job.invoke(invoke_pre_check_delay=7)
+        time.sleep(3)
+        bn = ii.get_build_number()
+        self.assertIsInstance(bn, int)
+        ii.block(until='not_queued')
+        self.assertTrue(ii.is_running())
+        b = ii.get_build()
+        self.assertIsInstance(b, Build)
+        ii.stop()
+        self.assertFalse(ii.is_running())
+        self.assertIsInstance(ii.get_build().get_console(), str)
+        self.assertIn('Started by user', ii.get_build().get_console())
+
+    def test_get_block_until_build_complete(self):
+        job_name = 'create_%s' % random_string()
+        job = self.hudson.create_job(job_name, SHORTISH_JOB)
+        ii = job.invoke()
+        ii.block(until='completed')
+        self.assertFalse(ii.is_running())
+
+    def test_multiple_invocations_and_get_last_build(self):
+        job_name = 'create_%s' % random_string()
+
+        job = self.hudson.create_job(job_name, SHORTISH_JOB)
+
+        for _ in range(3):
+            ii = job.invoke()
+            ii.block(until='completed')
+
+        build_number = job.get_last_good_buildnumber()
+        self.assertEquals(build_number, 3)
+
+        build = job.get_build(build_number)
+        self.assertIsInstance(build, Build)
+
+    def test_multiple_invocations_and_get_build_number(self):
+        job_name = 'create_%s' % random_string()
+
+        job = self.hudson.create_job(job_name, EMPTY_JOB)
+
+        for invocation in range(3):
+            ii = job.invoke()
+            ii.block(until='completed')
+            build_number = ii.get_build_number()
+            self.assertEquals(build_number, invocation + 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/jenkinsapi_tests/hudsontests/test_teamcreate.py
+++ b/jenkinsapi_tests/hudsontests/test_teamcreate.py
@@ -1,0 +1,73 @@
+'''
+Tests that jobs can be created in different teams
+'''
+import unittest
+import time
+from jenkinsapi.build import Build
+from jenkinsapi.invocation import Invocation
+from jenkinsapi_tests.hudsontests.base import BaseSystemTest
+from jenkinsapi_tests.test_utils.random_strings import random_string
+from jenkinsapi_tests.hudsontests.job_configs import LONG_RUNNING_JOB
+from jenkinsapi_tests.hudsontests.job_configs import SHORTISH_JOB, EMPTY_JOB
+
+
+class TestTeamCreate(BaseSystemTest):
+
+    def test_create_public_job(self):
+        """
+        Can we create a regular public job?
+        """
+        job_name = 'create_%s' % random_string()
+        job = self.hudson.create_job(job_name, SHORTISH_JOB)
+
+        self.assertEqual(job_name, job.name)
+        self.assertJobIsPresent(job_name)
+
+        ii = job.invoke(invoke_pre_check_delay=7)
+        self.assertIsInstance(ii, Invocation)
+        # Let hudson catchup
+        time.sleep(3)
+        self.assertTrue(ii.is_queued_or_running())
+        self.assertEquals(ii.get_build_number(), 1)
+
+    def test_create_team_job(self):
+        """
+        Can we create a job in a team?
+        """
+        job_name = 'create_%s' % random_string()
+        full_job_name ="one." +job_name
+        job = self.hudson.create_job(job_name, SHORTISH_JOB,"one")
+
+        self.assertEqual(full_job_name, job.name)
+        self.assertJobIsPresent(full_job_name)
+
+        ii = job.invoke(invoke_pre_check_delay=7)
+        self.assertIsInstance(ii, Invocation)
+        # Let hudson catchup
+        time.sleep(3)
+        self.assertTrue(ii.is_queued_or_running())
+        self.assertEquals(ii.get_build_number(), 1)
+
+    def test_create_same_job_in_different_teams(self):
+        """
+        Can we create the same job in different teams?
+        """
+
+        job_name = 'create_%s' % random_string()
+        team_one_job = self.hudson.create_job(job_name, SHORTISH_JOB,"one")
+        team_two_job = self.hudson.create_job(job_name, SHORTISH_JOB,"two")
+        public_job = self.hudson.create_job(job_name, SHORTISH_JOB)
+
+        self.assertEqual("one." + job_name, team_one_job.name)
+        self.assertEqual("two." + job_name, team_two_job.name)
+        self.assertEqual(job_name, public_job.name)
+
+        self.assertJobIsPresent(job_name)
+        self.assertJobIsPresent("one." + job_name)
+        self.assertJobIsPresent("two." + job_name)
+
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/jenkinsapi_tests/unittests/test_json.py
+++ b/jenkinsapi_tests/unittests/test_json.py
@@ -1,0 +1,45 @@
+import pytz
+import mock
+import unittest
+import datetime
+
+try:
+    import json
+except ImportError:
+    import simplejson as json
+
+from jenkinsapi.jenkinsbase import JenkinsBase
+
+
+class test_json(unittest.TestCase):
+
+    DATA = {
+        'actions': [
+            { 'act1':  {'name': 'val' }},
+            { 'act2':  {'name': 'val2' }}
+            ],
+        'post': [
+            "post1",
+            "post2",
+        ]
+        }
+
+    def setUp(self):
+        pass
+
+    def test_json_to_str(self):
+        jb = JenkinsBase("http://localhost", False)
+        jdump = json.dumps(self.DATA)
+        response_with_unicode = json.loads(jdump)
+        response_with_str = json.loads(jdump, object_hook=jb._decode_dict)
+        self.assertAlmostEqual(response_with_str,response_with_unicode, "Data structure is not the same")
+
+        self.assertTrue(isinstance(response_with_str['actions'][0]['act1']['name'], str), "name is not string")
+        self.assertTrue(isinstance(response_with_str['post'][0], str), "name is not string")
+
+
+def main():
+    unittest.main(verbosity=2)
+
+if __name__ == '__main__':
+    main()

--- a/jenkinsapi_utils/hudson_launcher.py
+++ b/jenkinsapi_utils/hudson_launcher.py
@@ -1,0 +1,225 @@
+import os
+import time
+import Queue
+import random
+import shutil
+import logging
+import datetime
+import tempfile
+import requests
+import threading
+import subprocess
+import pkg_resources
+
+from jenkinsapi.jenkins import Jenkins
+from jenkinsapi.custom_exceptions import JenkinsAPIException
+
+log = logging.getLogger(__name__)
+
+
+class FailedToStart(Exception):
+    pass
+
+
+class TimeOut(Exception):
+    pass
+
+
+class StreamThread(threading.Thread):
+
+    def __init__(self, name, q, stream, fn_log):
+        threading.Thread.__init__(self)
+        self.name = name
+        self.q = q
+        self.stream = stream
+        self.fn_log = fn_log
+
+    def run(self):
+        log.info("Starting %s", self.name)
+
+        while True:
+            line = self.stream.readline()
+            if line:
+                self.fn_log(line.rstrip())
+                self.q.put((self.name, line))
+            else:
+                break
+        self.q.put((self.name, None))
+
+
+class HudsonLancher(object):
+
+    """
+    Launch jenkins
+    """
+    HUDSON_WAR_URL = "http://eclipse.org/downloads/download.php?file=/hudson/war/hudson-3.1.0.war&r=1"
+
+    def __init__(self, war_path, plugin_urls=None):
+        self.war_path = war_path
+        self.war_directory, self.war_filename = os.path.split(self.war_path)
+        self.hudson_home = tempfile.mkdtemp(prefix='hudson-home-')
+        self.hudson_process = None
+        self.q = Queue.Queue()
+        self.plugin_urls = plugin_urls or []
+        self.http_port = random.randint(9000, 10000)
+
+    def update_war(self):
+        os.chdir(self.war_directory)
+        if os.path.exists(self.war_path):
+            log.info("We already have the Hudson War file...")
+        else:
+            log.info("Redownloading Hudson")
+            subprocess.check_call('./get-hudson-war.sh')
+
+    def update_config(self):
+        config_dest = os.path.join(self.hudson_home, 'config.xml')
+        config_dest_file = open(config_dest, 'w')
+        config_source = pkg_resources.resource_string('jenkinsapi_tests.hudsontests', 'config.xml')
+        config_dest_file.write(config_source.encode('UTF-8'))
+
+    def update_initsetup(self):
+        config_dest = os.path.join(self.hudson_home, 'initSetup.xml')
+        config_dest_file = open(config_dest, 'w')
+        config_source = pkg_resources.resource_string('jenkinsapi_tests.hudsontests', 'initSetup.xml')
+        config_dest_file.write(config_source.encode('UTF-8'))
+
+    def update_security(self):
+        config_dest = os.path.join(self.hudson_home, 'hudson-security.xml')
+        config_dest_file = open(config_dest, 'w')
+        config_source = pkg_resources.resource_string('jenkinsapi_tests.hudsontests', 'security.xml')
+        config_dest_file.write(config_source.encode('UTF-8'))
+
+    def update_teams(self):
+
+        team_one_dir = os.path.join(self.hudson_home, 'teams/one/jobs')
+        if not os.path.exists(team_one_dir):
+            os.makedirs(team_one_dir)
+
+        team_two_dir = os.path.join(self.hudson_home, 'teams/two/jobs')
+        if not os.path.exists(team_two_dir):
+            os.makedirs(team_two_dir)
+
+        config_dest = os.path.join(self.hudson_home, 'teams/teams.xml')
+        config_dest_file = open(config_dest, 'w')
+        config_source = pkg_resources.resource_string('jenkinsapi_tests.hudsontests', 'teams.xml')
+        config_dest_file.write(config_source.encode('UTF-8'))
+
+    def update_adminuser(self):
+        user_dir = os.path.join(self.hudson_home, 'users/admin')
+        if not os.path.exists(user_dir):
+            os.makedirs(user_dir)
+        config_dest = os.path.join(user_dir, 'config.xml')
+        config_dest_file = open(config_dest, 'w')
+        config_source = pkg_resources.resource_string('jenkinsapi_tests.hudsontests', 'admin-user.xml')
+        config_dest_file.write(config_source.encode('UTF-8'))
+
+
+
+
+    def install_plugins(self):
+        for i, url in enumerate(self.plugin_urls):
+            self.install_plugin(url, i)
+
+    def install_plugin(self, hpi_url, i):
+        plugin_dir = os.path.join(self.hudson_home, 'plugins')
+        if not os.path.exists(plugin_dir):
+            os.mkdir(plugin_dir)
+
+        log.info("Downloading %s", hpi_url)
+        log.info("Plugins will be installed in '%s'" % plugin_dir)
+        # FIXME: This is kinda ugly but works
+        filename = "plugin_%s.hpi" % i
+        plugin_path = os.path.join(plugin_dir, filename)
+        with open(plugin_path, 'wb') as h:
+            request = requests.get(hpi_url)
+            h.write(request.content)
+
+    def stop(self):
+        log.info("Shutting down Hudson.")
+        self.hudson_process.terminate()
+        self.hudson_process.wait()
+        shutil.rmtree(self.hudson_home)
+
+    def block_until_hudson_ready(self, timeout, port):
+        start_time = datetime.datetime.now()
+        timeout_time = start_time + datetime.timedelta(seconds=timeout)
+
+        while True:
+            try:
+                Jenkins('http://localhost:%s' % port)
+                log.info('Hudson is finally ready for use.')
+            except JenkinsAPIException:
+                log.info('Hudson is not yet ready...')
+            if datetime.datetime.now() > timeout_time:
+                raise TimeOut('Took too long for Jenkins to become ready...')
+            time.sleep(5)
+
+    def start(self, timeout=60):
+        self.update_war()
+        self.update_config()
+        self.update_initsetup()
+        self.update_security()
+        self.update_teams()
+        self.update_adminuser()
+        self.install_plugins()
+
+        os.environ['HUDSON_HOME'] = self.hudson_home
+        os.chdir(self.war_directory)
+
+        hudson_command = ['java', '-jar', self.war_filename,
+            '--httpPort=%d' % self.http_port , "--skipInitSetup"]
+
+        log.info("About to start Hudson...")
+        log.info("%s> %s", os.getcwd(), " ".join(hudson_command))
+        self.hudson_process = subprocess.Popen(
+            hudson_command, stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+        threads = [
+            StreamThread('out', self.q, self.hudson_process.stdout, log.info),
+            StreamThread('err', self.q, self.hudson_process.stderr, log.warn)
+        ]
+
+        # Start the threads
+        for t in threads:
+            t.start()
+
+        while True:
+            try:
+                streamName, line = self.q.get(block=True, timeout=timeout)
+            except Queue.Empty:
+                log.warn("Input ended unexpectedly")
+                break
+            else:
+                if line:
+                    if 'Failed to initialize Hudson' in line:
+                        raise FailedToStart(line)
+
+                    if 'Invalid or corrupt jarfile' in line:
+                        raise FailedToStart(line)
+
+                    if 'Hudson is ready' in line:
+                        log.info(line)
+                        return
+                else:
+                    log.warn('Stream %s has terminated', streamName)
+
+        self.block_until_hudson_ready(timeout, self.http_port)
+
+
+if __name__ == '__main__':
+    logging.basicConfig()
+    logging.getLogger('').setLevel(logging.INFO)
+
+    log.info("Hello!")
+
+    jl = HudsonLancher(
+        '/home/sal/workspace/jenkinsapi/src/jenkinsapi_tests/hudsontests/hudson.war'
+    )
+    jl.start()
+    log.info("Hudson was launched...")
+
+    time.sleep(30)
+
+    log.info("...now to shut it down!")
+    jl.stop()


### PR DESCRIPTION
This is a redo of my initial two pull requests. Once the testing code was added it was easier to merge the two.

For the Hudson testing I added a "hudsontests" module which sets up a hudson 3.1.0 instance with 2 teams and a admin user and runs some simple invocaiton tests copied form systests and some new tests to check if jobs can be created in different teams.

Longer terms it might be worth looking into running a common set of systests against both hudson and jenkins but I wasn't sure how to approach that, and it would properly be too big a refactoring for a simple pulll request
- Changed parsing of responses to use json, and use object_hook to ensure str is returned
  instead of unicode
- Add test_json to test the above
- Add team parameter to create job so jobs can be placed in a team. Backwards compatible so
  if no team is provided a public / normal job is created
- Add hudsontests to download Hudson 3.1.0 and test that jobs can be invoked and jobs can be created
  in different teams
