### PR TITLE
Method for retrieving the last stable build

### DIFF
--- a/jenkinsapi/job.py
+++ b/jenkinsapi/job.py
@@ -207,6 +207,7 @@ class Job(JenkinsBase, MutableJenkinsThing):
         """Gets a buildid for a given type of build"""
         self.poll()
         KNOWNBUILDTYPES = [
+            "lastStableBuild",
             "lastSuccessfulBuild",
             "lastBuild",
             "lastCompletedBuild",
@@ -223,6 +224,12 @@ class Job(JenkinsBase, MutableJenkinsThing):
         Get the numerical ID of the first build.
         """
         return self._buildid_for_type("firstBuild")
+
+    def get_last_stable_buildnumber(self):
+        """
+        Get the numerical ID of the last stable build.
+        """
+        return self._buildid_for_type("lastStableBuild")
 
     def get_last_good_buildnumber(self):
         """
@@ -283,6 +290,13 @@ class Job(JenkinsBase, MutableJenkinsThing):
         Return the next build number that Jenkins will assign.
         """
         return self._data.get('nextBuildNumber', 0)
+
+    def get_last_stable_build(self):
+        """
+        Get the last stable build
+        """
+        bn = self.get_last_stable_buildnumber()
+        return self.get_build(bn)
 
     def get_last_good_build(self):
         """

--- a/jenkinsapi_tests/unittests/test_job.py
+++ b/jenkinsapi_tests/unittests/test_job.py
@@ -118,6 +118,11 @@ class TestJob(unittest.TestCase):
         self.assertTrue(ret, 3)
 
     @mock.patch.object(JenkinsBase, 'get_data', fakeGetData)
+    def test_get_last_stable_buildnumber(self):
+        ret = self.j.get_last_stable_buildnumber()
+        self.assertTrue(ret, 3)
+
+    @mock.patch.object(JenkinsBase, 'get_data', fakeGetData)
     def test_get_last_failed_buildnumber(self):
         with self.assertRaises(NoBuildData):
             self.j.get_last_failed_buildnumber()


### PR DESCRIPTION
There is no method for retrieving the last stable build while it's very handy
