### PR TITLE
Rewrote how we get the latest build number to guarantee ordering.

### DIFF
--- a/jenkinsapi/invocation.py
+++ b/jenkinsapi/invocation.py
@@ -37,8 +37,9 @@ class Invocation(object):
         """
         self.job.poll()
         newly_created_builds = set(self.job.get_build_dict().keys())
+
         if newly_created_builds:
-            self.build_number = newly_created_builds.pop()
+            self.build_number = sorted(list(newly_created_builds))[-1]
         else:
             try:
                 self.queue_item = self.job.get_queue_item()


### PR DESCRIPTION
The previous design was to grab the list of build-numbers, and load them into a set(). This only makes sense if there is a possibility of duplicates, so I'm assuming that is the case.

However, a set does not guarantee order. We now convert it to a list, sort it, and grab the last (highest) value.

Though I can't guarantee that this fixes the wrong build-number being returned from the invocation object, it would make sense. Either way, this is still a bug that needs to be fixed.
