### PR TITLE
logging fix for invalid response

### DIFF
--- a/jenkinsapi/jenkinsbase.py
+++ b/jenkinsapi/jenkinsbase.py
@@ -60,7 +60,7 @@ class JenkinsBase(object):
     def get_data(self, url, params=None):
         requester = self.get_jenkins_obj().requester
         response = requester.get_url(url, params)
-        if response.status_code != 200 :
+        if response.status_code != 200:
             response.raise_for_status()
         try:
             return ast.literal_eval(response.text)


### PR DESCRIPTION
If you use an authenticated jenkins and you pass in an incorrect password the response.text it returns will not be valid to parse by ast, but the current logging logic covers up the actual HTTP error.  This will fix that by checdking if the response went through "status_code" of 200 and if not then raise and exception for the status so the end user can see why.

Also if you use the Jenkins class you will get and error:
No handlers could be found for logger "jenkinsapi.jenkinsbase"

To my knowledge logging inside of a package should be done by the logging.exception methods so the package user can specify their own handlers or configuration for logging.
