### PR TITLE
Build invoke fix

### DIFF
--- a/jenkinsapi/job.py
+++ b/jenkinsapi/job.py
@@ -126,7 +126,7 @@ class Job(JenkinsBase, MutableJenkinsThing):
             self._element_tree = ET.fromstring(self._config)
         return self._element_tree
 
-    def get_build_triggerurl(self, build_params=None, files=None):
+    def get_build_triggerurl(self):
         if len(self.get_params_list()) == 0:
             return "%s/build" % self.baseurl
         return "%s/buildWithParameters" % self.baseurl
@@ -182,7 +182,7 @@ class Job(JenkinsBase, MutableJenkinsThing):
             log.info("Attempting to start %s on %s", self.name, repr(
                 self.get_jenkins_obj()))
 
-            url = self.get_build_triggerurl(build_params, files)
+            url = self.get_build_triggerurl()
 
             if cause:
                 build_params['cause'] = cause


### PR DESCRIPTION
job.get_build_triggerurl had invalid logic for determining what build url to be using.  Parameterized builds can only be started via the rest API with the buildWithParameters endpoint even if you don't pass any parameters in.  This changes the logic to check if there are parameter definiations in the job config, which is present should then return the buildWithParameters endpoint.  Since we are now deriving this off of the config there is no reason to pass in previous arguments, so that has been cleaned up.
