### PR TITLE
polling jenkins each time Jobs is initialized

### DIFF
--- a/jenkinsapi/jobs.py
+++ b/jenkinsapi/jobs.py
@@ -18,6 +18,7 @@ class Jobs(object):
     """
     def __init__(self, jenkins):
         self.jenkins = jenkins
+        self.jenkins.poll()
 
     def __len__(self):
         return len(self.keys)


### PR DESCRIPTION
This ensure jobs list to be up-2-date.

Here's a use case leading to an error :
jenkinsapi is used within a forever process (let's say an API using Bottle).
This API exposes an URL to create jenkins jobs (using jenkinsapi).
If a job is created by the API then deleted directly from jenkins, it won't be possible to recreate this  exact same job from the API as the Jobs.create function polls after the creation. So for the API the job still exists.

This is a twisted use case but i'm running into it !
