### PR TITLE
Add support to create Jenkins object without immediately polling jobs.

### DIFF
--- a/jenkinsapi/jenkins.py
+++ b/jenkinsapi/jenkins.py
@@ -30,7 +30,7 @@ class Jenkins(JenkinsBase):
     """
     Represents a jenkins environment.
     """
-    def __init__(self, baseurl, username=None, password=None, requester=None):
+    def __init__(self, baseurl, username=None, password=None, requester=None, lazy=False):
         """
         :param baseurl: baseurl for jenkins instance including port, str
         :param username: username for jenkins auth, str
@@ -40,7 +40,12 @@ class Jenkins(JenkinsBase):
         self.username = username
         self.password = password
         self.requester = requester or Requester(username, password, baseurl=baseurl)
-        JenkinsBase.__init__(self, baseurl)
+        self.lazy = lazy
+        JenkinsBase.__init__(self, baseurl, poll=not lazy)
+
+    def _poll_if_needed(self):
+        if self.lazy and self._data is None:
+            self.poll()
 
     def _clone(self):
         return Jenkins(self.baseurl, username=self.username,
@@ -92,6 +97,7 @@ class Jenkins(JenkinsBase):
         """
         Fetch all the build-names on this Jenkins server.
         """
+        self._poll_if_needed()
         for info in self._data["jobs"]:
             yield info["name"], \
                 Job(info["url"], info["name"], jenkins_obj=self)
@@ -101,6 +107,7 @@ class Jenkins(JenkinsBase):
         Get the jobs information
         :return url, name
         """
+        self._poll_if_needed()
         for info in self._data["jobs"]:
             yield info["url"], info["name"]
 
@@ -159,6 +166,7 @@ class Jenkins(JenkinsBase):
         return self.jobs.rename(jobname, newjobname)
 
     def iterkeys(self):
+        self._poll_if_needed()
         for info in self._data["jobs"]:
             yield info["name"]
 
@@ -205,12 +213,15 @@ class Jenkins(JenkinsBase):
         :param jobname: name of job, str
         :return: Job obj
         """
+        self._poll_if_needed()
+
         for info in self._data["jobs"]:
             if info["name"] == jobname:
                 return Job(info["url"], info["name"], jenkins_obj=self)
         raise UnknownJob(jobname)
 
     def __len__(self):
+        self._poll_if_needed()
         return len(self._data["jobs"])
 
     def __contains__(self, jobname):


### PR DESCRIPTION
I work with a Jenkins server that has an extremely large number of jobs, including subfolders, and if JenkinsAPI loads all jobs upfront, the object initialisation takes almost 2 minutes.
