### PR TITLE
fix for job invoke when no build parameters exist for a particular job

### DIFF
--- a/jenkinsapi/job.py
+++ b/jenkinsapi/job.py
@@ -624,7 +624,10 @@ class Job(JenkinsBase, MutableJenkinsThing):
         return [param['name'] for param in self.get_params()]
 
     def has_params(self):
-        return len(self._data['actions']) > 0
+        """
+        If job has parameters, returns True, else False
+        """
+        return any("parameterDefinitions" in a for a in self._data["actions"])
 
     def has_queued_build(self, build_params):
         """Returns True if a build with build_params is currently queued."""


### PR DESCRIPTION
In version 0.2.18 and before, you could call invoke on a job that has no parameters and the job.py code would figure out which to call: build or buildWithParameters.

After version 0.2.18, the code changed and does not call build when there are no parameters on the job. The has_params method uses the length of the actions list to determine if there are parameters, however this list seems to always have a length > 0, even if the elements in the list are empty.

This patch looks for the parameterDefinitions key in the actions list to determine if there are parameters for the  job. 

To replicate the issue, create a job named "testjob" without parameters and run the following script:

```
from jenkinsapi.jenkins import Jenkins
j = Jenkins('http://jenkinsserver:8080', "user", "password")
params = {}
i = j['testjob'].invoke(build_params=params)
```

jenkins will return something along the lines of:

```
...
<a href="http://jenkins-ci.org/content/mailing-lists">The users list</a> might be also useful in understanding what has happened.</p><h2>Stack trace</h2><pre style="margin:2em; clear:both">javax.servlet.ServletException: java.lang.IllegalStateException: This build is not parameterized!
    at org.kohsuke.stapler.Stapler.tryInvoke(Stapler.java:778)
    at org.kohsuke.stapler.Stapler.invoke(Stapler.java:858)
    at org.kohsuke.stapler.MetaClass$6.doDispatch(MetaClass.java:248)
    at org.kohsuke.stapler.NameBasedDispatcher.dispatch(NameBasedDispatcher.java:53)
    at org.kohsuke.stapler.Stapler.tryInvoke(Stapler.java:728)
...
```

apply the patch and the job will be submitted properly.
