### PR TITLE
add logging url when non 200 OK response

### DIFF
--- a/jenkinsapi/jenkinsbase.py
+++ b/jenkinsapi/jenkinsbase.py
@@ -63,6 +63,7 @@ class JenkinsBase(object):
         requester = self.get_jenkins_obj().requester
         response = requester.get_url(url, params)
         if response.status_code != 200:
+            logging.error('Failed request at %s with params: %s', url, params)
             response.raise_for_status()
         try:
             return ast.literal_eval(response.text)


### PR DESCRIPTION
A quick fix for issue #273
Just logging an ERROR with URL and params when we getting non 200 code. It should be sufficient for a user of the lib to understand a root cause of a failure without setting a debug mode or anything.
It can be simply an auth problem and it's useful to see 403 on the spot.
