### PR TITLE
self signed ssl certificates cause error, currently there is no way to change the ssl verify flag

### DIFF
--- a/jenkinsapi/jenkins.py
+++ b/jenkinsapi/jenkins.py
@@ -37,17 +37,20 @@ class Jenkins(JenkinsBase):
     """
     Represents a jenkins environment.
     """
-    def __init__(self, baseurl, username=None, password=None, requester=None, lazy=False, ssl_verify=True):
+    def __init__(self, baseurl, username=None, password=None, requester=None,
+                 lazy=False, ssl_verify=True):
         """
         :param baseurl: baseurl for jenkins instance including port, str
         :param username: username for jenkins auth, str
         :param password: password for jenkins auth, str
-        :param ssl_verify: verify ssl certificate, boolean 
+        :param ssl_verify: verify ssl certificate, boolean
         :return: a Jenkins obj
         """
         self.username = username
         self.password = password
-        self.requester = requester or Requester(username, password, baseurl=baseurl, ssl_verify=ssl_verify)
+        self.requester = requester or Requester(username, password,
+                                                baseurl=baseurl,
+                                                ssl_verify=ssl_verify)
         self.lazy = lazy
         JenkinsBase.__init__(self, baseurl, poll=not lazy)
 


### PR DESCRIPTION
The following error is encountered if Jenkins is setup for SSL but with a self signed certificate:

```
requests.exceptions.SSLError: [Errno 1] _ssl.c:504: error:14090086:SSL routines:SSL3_GET_SERVER_CERTIFICATE:certificate verify failed
```

The Requester class supports the ssl_verify flag with gets passed to requests http handler. However this is not exposed to the Jenkins class so the programmer cannot use it. 

I added ssl_verify to the Jenkins class and this is passed to the Requester class when it is instantiated. It is true by default which will not cause issues with code already in place. To test you will need to setup a jenkins server with ssl and a self signed certificate. Tested as below:

```
j = Jenkins("https://serveraddress", "user", "password", ssl_verify=False)
```
