### PR TITLE
Fix Kerberos Request Module

### DIFF
--- a/jenkinsapi/utils/krb_requester.py
+++ b/jenkinsapi/utils/krb_requester.py
@@ -14,7 +14,8 @@ class KrbRequester(Requester):
 
     def __init__(self, ssl_verify=None, baseurl=None, mutual_auth=OPTIONAL):
         """
-        :param ssl_verify: flag indicating if server certificate in HTTPS requests should be verified
+        :param ssl_verify: flag indicating if server certificate in HTTPS requests should be
+                           verified
         :param baseurl: Jenkins' base URL
         :param mutual_auth: type of mutual authentication, use one of REQUIRED, OPTIONAL or DISABLED
                             from requests_kerberos package
@@ -28,7 +29,8 @@ class KrbRequester(Requester):
         self.mutual_auth = mutual_auth
 
     def get_request_dict(self, params=None, data=None, files=None, headers=None):
-      req_dict = super(KrbRequester, self).get_request_dict(params=params, data=data, files=files, headers=headers)
+      req_dict = super(KrbRequester, self).get_request_dict(params=params, data=data, files=files,
+                                                            headers=headers)
       if self.mutual_auth:
          auth = HTTPKerberosAuth(self.mutual_auth)
       else:


### PR DESCRIPTION
The interface for this class was broken; other objects called get_request_dict with only two parameters, wheras get_request_dict only accepted 4 parameters in the KrbRequester class. Fixed and manually tested with a kerberized API call, and also ran "ant test".
