### PR TITLE
return real queue item instead of None after job invocation

### DIFF
--- a/jenkinsapi/job.py
+++ b/jenkinsapi/job.py
@@ -220,7 +220,13 @@ class Job(JenkinsBase, MutableJenkinsThing):
                 files=files,
                 valid=[200, 201]
             )
-            response = response
+
+            queue_item_raw = self.jenkins.requester.get_and_confirm_status(
+                response.headers['location'] + '/api/json',
+                valid=[200])
+            queue_item = json.loads(queue_item_raw.text)
+            invocation.queue_item = QueueItem(self.jenkins, **queue_item)
+
             if invoke_pre_check_delay > 0:
                 log.info(
                     "Waiting for %is to allow Jenkins to catch up", invoke_pre_check_delay)

--- a/jenkinsapi/queue.py
+++ b/jenkinsapi/queue.py
@@ -5,6 +5,7 @@ Queue module for jenkinsapi
 from jenkinsapi.jenkinsbase import JenkinsBase
 from jenkinsapi.custom_exceptions import UnknownQueueItem
 import logging
+import json
 
 log = logging.getLogger(__name__)
 
@@ -106,3 +107,10 @@ class QueueItem(object):
 
     def __str__(self):
         return "%s #%i" % (self.task['name'], self.id)
+
+    def poll(self):
+        queue_item_raw = self.jenkins.requester.get_and_confirm_status(
+            self.jenkins.baseurl + '/' + self.url + '/api/json',
+            valid=[200])
+        queue_item = json.loads(queue_item_raw.text)
+        self.__dict__.update(**queue_item)


### PR DESCRIPTION
Also added a poll() method to queue item to check the status of execution.

With this two changes, it is now possible to trigger a build and wait for it to be executed and finished, also if parallel executions are enabled.

Should be a fix for #279 and #299 
