### PR TITLE
Fix a typo in a function name in queing

### DIFF
--- a/jenkinsapi/queue.py
+++ b/jenkinsapi/queue.py
@@ -37,7 +37,7 @@ class Queue(JenkinsBase):
         for item in self._data['items']:
             yield item['id']
 
-    def iterivalues(self):
+    def itervalues(self):
         for item in self._data['items']:
             yield QueueItem(self.jenkins, **item)
 


### PR DESCRIPTION
Replacing iterivalues() by itervalues(), and then fixing the values()
function of Queue object.
