### PR TITLE
allow configuration of views

### DIFF
--- a/jenkinsapi/view.py
+++ b/jenkinsapi/view.py
@@ -170,6 +170,14 @@ class View(JenkinsBase):
     def get_config_xml_url(self):
         return '%s/config.xml' % self.baseurl
 
+    def get_config(self):
+        """
+        Return the config.xml from the view
+        """
+        url = self.get_config_xml_url()
+        response = self.get_jenkins_obj().requester.get_and_confirm_status(url)
+        return response.text
+
     def update_config(self, config):
         """
         Update the config.xml to the view

--- a/jenkinsapi_tests/systests/test_views.py
+++ b/jenkinsapi_tests/systests/test_views.py
@@ -12,6 +12,7 @@ from jenkinsapi.view import View
 from jenkinsapi.views import Views
 from jenkinsapi.api import get_view_from_url
 from jenkinsapi_tests.systests.base import BaseSystemTest
+from jenkinsapi_tests.systests.view_configs import VIEW_WITH_FILTER_AND_REGEX
 from jenkinsapi_tests.test_utils.random_strings import random_string
 
 log = logging.getLogger(__name__)
@@ -58,6 +59,18 @@ class TestViews(BaseSystemTest):
         self.assertIn(view1_name, self.jenkins.views)
         del self.jenkins.views[view1_name]
         self.assertNotIn(view1_name, self.jenkins.views)
+
+    def test_update_view_config(self):
+        view_name = random_string()
+        new_view = self.jenkins.views.create(view_name)
+        self.assertIsInstance(new_view, View)
+        self.assertIn(view_name, self.jenkins.views)
+        config = self.jenkins.views[view_name].get_config().strip()
+        new_view_config = VIEW_WITH_FILTER_AND_REGEX % view_name
+        self.assertNotEquals(config, new_view_config)
+        self.jenkins.views[view_name].update_config(new_view_config)
+        config = self.jenkins.views[view_name].get_config().strip()
+        self.assertEquals(config, new_view_config)
 
     def test_make_nested_views(self):
         job = self._create_job()

--- a/jenkinsapi_tests/systests/view_configs.py
+++ b/jenkinsapi_tests/systests/view_configs.py
@@ -1,0 +1,28 @@
+"""
+A selection of view objects used in testing.
+"""
+
+VIEW_WITH_FILTER_AND_REGEX = """
+<?xml version="1.0" encoding="UTF-8"?>
+<hudson.model.ListView>
+  <name>%s</name>
+  <filterExecutors>true</filterExecutors>
+  <filterQueue>true</filterQueue>
+  <properties class="hudson.model.View$PropertyList"/>
+  <jobNames>
+    <comparator class="hudson.util.CaseInsensitiveComparator"/>
+  </jobNames>
+  <jobFilters/>
+  <columns>
+    <hudson.views.StatusColumn/>
+    <hudson.views.WeatherColumn/>
+    <hudson.views.JobColumn/>
+    <hudson.views.LastSuccessColumn/>
+    <hudson.views.LastFailureColumn/>
+    <hudson.views.LastDurationColumn/>
+    <hudson.views.BuildButtonColumn/>
+  </columns>
+  <includeRegex>regex</includeRegex>
+  <recurse>false</recurse>
+</hudson.model.ListView>
+""".strip()


### PR DESCRIPTION
Currently views can only be created / deleted but not configured (beyond the view type).

This PR adds a `update_config()` method to the `view` class which is symmetric to the same function in the `job` class (https://github.com/salimfadhley/jenkinsapi/blob/d0ed211b8415ccf38628c81b3ca0a429bc7da90d/jenkinsapi/job.py#L522).
