### PR TITLE
Job.set_owner() and Job.get_owner() methods added. They works with job owner propert...

### DIFF
--- a/jenkinsapi/job.py
+++ b/jenkinsapi/job.py
@@ -655,3 +655,54 @@ class Job(JenkinsBase, MutableJenkinsThing):
             if build.get_parameters() == build_params:
                 return True
         return False
+
+    def get_owner(self):
+        """
+        Returns job owner.
+        Requires 'Job and Slave ownership plugin.
+        """
+        primary_owner_id_elem = self._get_config_element_tree().find('properties/com.synopsys.arc.jenkins.plugins.ownership.jobs.JobOwnerJobProperty/ownership/primaryOwnerId')
+        if None == primary_owner_id_elem:
+            return None
+        else:
+            return primary_owner_id_elem.text
+ 
+    def set_owner(self, owner):
+        """
+        Sets owner of the job. 
+        Requires "Job and Slave ownership" plugin.
+         
+        Arguments:
+            owner - jenkins user name of the job owner.
+        """
+        primary_owner_id_elem = self._get_config_element_tree().find('properties/com.synopsys.arc.jenkins.plugins.ownership.jobs.JobOwnerJobProperty/ownership/primaryOwnerId')
+        if primary_owner_id_elem is not None:
+            if owner != primary_owner_id_elem.text:
+                primary_owner_id_elem.text = owner
+            return primary_owner_id_elem.text
+        else:
+            log.debug('Config of the job "{job_name}" does not have JobOwnerJobProperty section. Will be added now.'.format(job_name=self.name))
+            project_properties_elem = self._get_config_element_tree().find('properties')
+            
+            # create new section for Job Owner plugin info.
+            job_owner_root_elem = ET.Element('com.synopsys.arc.jenkins.plugins.ownership.jobs.JobOwnerJobProperty')
+            job_owner_root_elem.set('plugin', 'ownership@0.5.1')
+            project_properties_elem.append(job_owner_root_elem)
+            
+            ownership_elem = ET.Element('ownership')
+            job_owner_root_elem.append(ownership_elem)
+
+            ownership_enabled_elem = ET.Element('ownershipEnabled')
+            ownership_enabled_elem.text = 'true'
+            primary_owner_id_elem = ET.Element('primaryOwnerId')
+            primary_owner_id_elem.text = owner
+            coowners_ids_elem = ET.Element('coownersIds')
+            coowners_ids_elem.set('class', 'sorted-set')
+
+            ownership_elem.append(ownership_enabled_elem)
+            ownership_elem.append(primary_owner_id_elem)
+            ownership_elem.append(coowners_ids_elem)
+
+            log.debug('owner ID added. Storing changed job {job_name} to server.'.format(job_name=self.name))
+            self.update_config(config=ET.tostring(self._get_config_element_tree()))
+


### PR DESCRIPTION
Job.set_owner() and Job.get_owner() methods added. They works with job owner property.

This property appears when "Job and Slave ownership" plugin installed. When plugin is not installed, Jenkins ignores changes performed by set_owner.
