### PR TITLE
Categorized view plugin support and change View#add_job approach

### DIFF
--- a/examples/how_to/create_views.py
+++ b/examples/how_to/create_views.py
@@ -50,3 +50,20 @@ else:
 # No error will be raised when attempting to remove non-existing view
 logger.info('Attempting to delete view that does not exist')
 del api.views[test_view_name]
+
+# Create CategorizedJobsView
+config = '''
+<org.jenkinsci.plugins.categorizedview.CategorizedJobsView>
+  <categorizationCriteria>
+    <org.jenkinsci.plugins.categorizedview.GroupingRule>
+      <groupRegex>.dev.</groupRegex>
+      <namingRule>Development</namingRule>
+    </org.jenkinsci.plugins.categorizedview.GroupingRule>
+    <org.jenkinsci.plugins.categorizedview.GroupingRule>
+      <groupRegex>.hml.</groupRegex>
+      <namingRule>Homologation</namingRule>
+    </org.jenkinsci.plugins.categorizedview.GroupingRule>
+  </categorizationCriteria>
+</org.jenkinsci.plugins.categorizedview.CategorizedJobsView>
+'''
+view = api.views.create('My categorized jobs view', api.views.CATEGORIZED_VIEW, config=config)

--- a/jenkinsapi/view.py
+++ b/jenkinsapi/view.py
@@ -125,39 +125,14 @@ class View(JenkinsBase):
                     job = top_jenkins.get_job(str_job_name)
 
         log.info(msg='Creating job %s in view %s' % (str_job_name, self.name))
-        data = {
-            "description": "",
-            "statusFilter": "",
-            "useincluderegex": "on",
-            "includeRegex": "",
-            "columns": [{"stapler-class": "hudson.views.StatusColumn",
-                         "kind": "hudson.views.StatusColumn"},
-                        {"stapler-class": "hudson.views.WeatherColumn",
-                         "kind": "hudson.views.WeatherColumn"},
-                        {"stapler-class": "hudson.views.JobColumn",
-                         "kind": "hudson.views.JobColumn"},
-                        {"stapler-class": "hudson.views.LastSuccessColumn",
-                         "kind": "hudson.views.LastSuccessColumn"},
-                        {"stapler-class": "hudson.views.LastFailureColumn",
-                         "kind": "hudson.views.LastFailureColumn"},
-                        {"stapler-class": "hudson.views.LastDurationColumn",
-                         "kind": "hudson.views.LastDurationColumn"},
-                        {"stapler-class": "hudson.views.BuildButtonColumn",
-                         "kind": "hudson.views.BuildButtonColumn"}],
-            "Submit": "OK",
-        }
-        data["name"] = self.name
-        # Add existing jobs (if any)
-        for job_name in self.get_job_dict().keys():
-            data[job_name] = 'on'
 
-        # Add new job
-        data[job.name] = 'on'
+        url = '%s/addJobToView' % self.baseurl
+        params = {'name': str_job_name}
 
-        data['json'] = data.copy()
-        data = urlencode(data)
         self.get_jenkins_obj().requester.post_and_confirm_status(
-            '%s/configSubmit' % self.baseurl, data=data)
+            url,
+            data={},
+            params=params)
         self.poll()
         log.debug(msg='Job "%s" has been added to a view "%s"' %
                   (job.name, self.name))

--- a/jenkinsapi/view.py
+++ b/jenkinsapi/view.py
@@ -1,12 +1,6 @@
 """
 Module for jenkinsapi views
 """
-try:
-    from urllib import urlencode
-except ImportError:
-    # Python3
-    from urllib.parse import urlencode
-
 import logging
 
 from jenkinsapi.jenkinsbase import JenkinsBase


### PR DESCRIPTION
closes #467 

- adds support for [Categorized Jobs View plugin](https://wiki.jenkins-ci.org/display/JENKINS/Categorized+Jobs+View)
- change `View#add_job` to use the `addJobToView` action. This was needed because, even though I could add a Categorized Jobs View correctly, after adding jobs to it, it would have some configs erased.

I'm opening this PR so you can tell me whether this is good enough, or how should I improve. I'll write the tests as soon as you tell me the approach is correct.

I run the existing tests locally after the changes and they are all green. And I tested the new feature against my Jenkins instance and it works fine.