### PR TITLE
Strict artefact systest

### DIFF
--- a/jenkinsapi/artifact.py
+++ b/jenkinsapi/artifact.py
@@ -70,14 +70,15 @@ class Artifact(object):
         Grab the text of the artifact
         """
         response = self.get_jenkins_obj().requester.get_and_confirm_status(
-            self.url, stream=True)
-        return response
+            self.url)
+        return response.content
 
     def _do_download(self, fspath):
         """
         Download the the artifact to a path.
         """
-        data = self.get_data()
+        data = self.get_jenkins_obj().requester.get_and_confirm_status(
+            self.url, stream=True)
         with open(fspath, "wb") as out:
             for chunk in data.iter_content(chunk_size=1024):
                 out.write(chunk)

--- a/jenkinsapi/utils/requester.py
+++ b/jenkinsapi/utils/requester.py
@@ -92,11 +92,14 @@ class Requester(object):
             )
         return url
 
-    def get_url(self, url, params=None, headers=None, allow_redirects=True):
+    def get_url(self, url, params=None, headers=None, allow_redirects=True,
+                stream=False):
         requestKwargs = self.get_request_dict(
             params=params,
             headers=headers,
-            allow_redirects=allow_redirects)
+            allow_redirects=allow_redirects,
+            stream=stream
+        )
         return requests.get(self._update_url_scheme(url), **requestKwargs)
 
     def post_url(self, url, params=None, data=None, files=None,
@@ -136,9 +139,9 @@ class Requester(object):
         return response
 
     def get_and_confirm_status(
-            self, url, params=None, headers=None, valid=None):
+            self, url, params=None, headers=None, valid=None, stream=False):
         valid = valid or self.VALID_STATUS_CODES
-        response = self.get_url(url, params, headers)
+        response = self.get_url(url, params, headers, stream=stream)
         if response.status_code not in valid:
             if response.status_code == 405:         # POST required
                 raise PostRequired('POST required for url {0}'.format(url))

--- a/jenkinsapi_tests/systests/job_configs.py
+++ b/jenkinsapi_tests/systests/job_configs.py
@@ -149,7 +149,7 @@ gzip &lt; out.txt &gt; out.gz</command>
       <latestOnly>false</latestOnly>
     </hudson.tasks.ArtifactArchiver>
     <hudson.tasks.Fingerprinter>
-      <targets></targets>
+      <targets>*.*</targets>
       <recordBuildArtifacts>true</recordBuildArtifacts>
     </hudson.tasks.Fingerprinter>
   </publishers>

--- a/jenkinsapi_tests/systests/test_jenkins_artifacts.py
+++ b/jenkinsapi_tests/systests/test_jenkins_artifacts.py
@@ -40,7 +40,7 @@ class TestPingerJob(BaseSystemTest):
 
         try:
             # Verify that we can handle text artifacts
-            text_artifact.save_to_dir(tempDir)
+            text_artifact.save_to_dir(tempDir, strict_validation=True)
             readBackText = open(os.path.join(tempDir,
                                              text_artifact.filename),
                                 'rb').read().strip()
@@ -49,7 +49,7 @@ class TestPingerJob(BaseSystemTest):
             self.assertTrue(readBackText.endswith('ms'))
 
             # Verify that we can hande binary artifacts
-            binary_artifact.save_to_dir(tempDir)
+            binary_artifact.save_to_dir(tempDir, strict_validation=True)
             readBackText = gzip.open(os.path.join(tempDir,
                                                   binary_artifact.filename,),
                                      'rb').read().strip()


### PR DESCRIPTION
Made systest for artefact to be run with strict md5 check.
Artifact download now will not use `response.content`, but will use stream of binary chunks.