### PR TITLE
Add ability to retrieve build by params

### DIFF
--- a/jenkinsapi/build.py
+++ b/jenkinsapi/build.py
@@ -93,11 +93,13 @@ class Build(JenkinsBase):
 
     def get_params(self):
         """
-        Return a dictionary of params names and their values
+        Return a dictionary of params names and their values or None
+        if no parameters present
         """
-        parameters = self._data.get('actions', {})[0].get('parameters', )
-        result = {pair['name']: pair['value'] for pair in parameters}
-        return result
+        actions = self._data.get('actions')
+        if actions:
+            parameters = actions[0].get('parameters', {})
+            return {pair['name']: pair['value'] for pair in parameters}
 
     def get_changeset_items(self):
         """

--- a/jenkinsapi/build.py
+++ b/jenkinsapi/build.py
@@ -92,12 +92,11 @@ class Build(JenkinsBase):
         return getattr(self, '_get_%s_rev_branch' % vcs, lambda: None)()
 
     def get_params(self):
-        result = {}
-        parameters = self._data.get('actions', {})[0].get('parameters', {})
-        for pair in parameters:
-            key = pair['name']
-            value = pair['value']
-            result[key] = value
+        """
+        Return a dictionary of params names and their values
+        """
+        parameters = self._data.get('actions', {})[0].get('parameters', )
+        result = {pair['name']: pair['value'] for pair in parameters}
         return result
 
     def get_changeset_items(self):

--- a/jenkinsapi/build.py
+++ b/jenkinsapi/build.py
@@ -91,6 +91,15 @@ class Build(JenkinsBase):
         vcs = self._data['changeSet']['kind'] or 'git'
         return getattr(self, '_get_%s_rev_branch' % vcs, lambda: None)()
 
+    def get_params(self):
+        result = {}
+        parameters = self._data.get('actions', {})[0].get('parameters', {})
+        for pair in parameters:
+            key = pair['name']
+            value = pair['value']
+            result[key] = value
+        return result
+
     def get_changeset_items(self):
         """
         Returns a list of changeSet items.

--- a/jenkinsapi/job.py
+++ b/jenkinsapi/job.py
@@ -298,7 +298,7 @@ class Job(JenkinsBase, MutableJenkinsThing):
         last_build_number = self.get_last_buildnumber()
         assert order == 1 or order == -1, 'Direction should be ascending or descending (1/-1)'
 
-        for number in range(first_build_number, last_build_number+1)[::order]:
+        for number in range(first_build_number, last_build_number + 1)[::order]:
             build = self.get_build(number)
             if build.get_params() == build_params:
                 return build

--- a/jenkinsapi/job.py
+++ b/jenkinsapi/job.py
@@ -293,6 +293,18 @@ class Job(JenkinsBase, MutableJenkinsThing):
         # understand the test above.
         return dict((build["number"], build["url"]) for build in builds)
 
+    def get_build_by_params(self, build_params, order=1):
+        first_build_number = self.get_first_buildnumber()
+        last_build_number = self.get_last_buildnumber()
+        assert order == 1 or order == -1, 'Direction should be ascending or descending (1/-1)'
+
+        for number in range(first_build_number, last_build_number+1)[::order]:
+            build = self.get_build(number)
+            if build.get_params() == build_params:
+                return build
+
+        raise NoBuildData('No build with such params {params}'.format(params=build_params))
+
     def get_revision_dict(self):
         """
         Get dictionary of all revisions with a list of buildnumbers (int)

--- a/jenkinsapi_tests/unittests/test_build.py
+++ b/jenkinsapi_tests/unittests/test_build.py
@@ -105,10 +105,6 @@ class test_build(unittest.TestCase):
         """ with no scm, get_revision should return None """
         self.assertEqual(self.b.get_revision(), None)
 
-    def test_get_revision_no_scm(self):
-        """ with no scm, get_revision should return None """
-        self.assertEqual(self.b.get_revision(), None)
-
     @mock.patch.object(Build, '__init__')
     def test_get_matrix_runs(self, build_init_mock):
         build_init_mock.return_value = None
@@ -116,6 +112,23 @@ class test_build(unittest.TestCase):
             continue
         build_init_mock.assert_called_once_with('http//localhost:8080/job/foo/SHARD_NUM=1/1/',
                                                 1, self.j)
+
+    def test_get_params(self):
+        expected = {
+            'first_param': 'first_value',
+            'second_param': 'second_value',
+        }
+        self.b._data = {
+            'actions': [{
+                'parameters': [
+                    {'name': 'first_param', 'value': 'first_value'},
+                    {'name': 'second_param', 'value': 'second_value'},
+                ]
+            }]
+        }
+        params = self.b.get_params()
+
+        self.assertDictEqual(params, expected)
 
     # TEST DISABLED - DOES NOT WORK
     # def test_downstream(self):

--- a/jenkinsapi_tests/unittests/test_job.py
+++ b/jenkinsapi_tests/unittests/test_job.py
@@ -340,5 +340,20 @@ class TestJob(unittest.TestCase):
         self.assertEquals(
             str(ar.exception), 'Build parameters must be a dict')
 
+    def test_get_build_by_params(self):
+        build_params = {
+            'param1': 'value1'
+        }
+        get_params_mock = mock.Mock(side_effect=({}, {}, build_params))
+        build_mock = mock.Mock(get_params=get_params_mock)
+        with mock.patch.object(self.j, 'get_first_buildnumber', return_value=1), \
+                mock.patch.object(self.j, 'get_last_buildnumber', return_value=3), \
+                mock.patch.object(self.j, 'get_build', return_value=build_mock) as get_build_mock:
+            result = self.j.get_build_by_params(build_params)
+            assert get_build_mock.call_count == 3
+            assert get_params_mock.call_count == 3
+            assert result == build_mock
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Rationale
Sometimes it's useful to have an ability of retrieving build by params the job was launched with. For example, if you want to fetch a last/first build for the specific params.

## Changes
* Add 'get_params' for the build that allows to get dictionary with params
* Add 'get_build_by_params' to the job class that will compare build params with the specified one by one
* Add unittests

## Notes
'get_build_by_params' method will make requests for each build, so it's network consuming call and makes sense only if you want to get first/last build by param (`order` keyword will help you) or have small amount of build ~20-30.