### PR TITLE
Implement `Secret text` credential

### DIFF
--- a/jenkinsapi/credential.py
+++ b/jenkinsapi/credential.py
@@ -95,6 +95,53 @@ class UsernamePasswordCredential(Credential):
         }
 
 
+class SecretTextCredential(Credential):
+    """
+    Secret text credential
+
+    Constructor expects following dict:
+        {
+            'credential_id': str,   Automatically set by jenkinsapi
+            'displayName': str,     Automatically set by Jenkins
+            'fullName': str,        Automatically set by Jenkins
+            'typeName': str,        Automatically set by Jenkins
+            'description': str,
+            'secret': str,
+        }
+
+    When creating credential via jenkinsapi automatic fields not need to be in
+    dict
+    """
+
+    def __init__(self, cred_dict):
+        super(SecretTextCredential, self).__init__(cred_dict)
+        self.secret = cred_dict.get('secret', None)
+
+    def get_attributes(self):
+        """
+        Used by Credentials object to create credential in Jenkins
+        """
+        c_class = (
+            'org.jenkinsci.plugins.plaincredentials.impl.'
+            'StringCredentialsImpl'
+        )
+        c_id = '' if self.credential_id is None else self.credential_id
+        return {
+            'stapler-class': c_class,
+            'Submit': 'OK',
+            'json': {
+                '': '1',
+                'credentials': {
+                    'stapler-class': c_class,
+                    '$class': c_class,
+                    'id': c_id,
+                    'secret': self.secret,
+                    'description': self.description
+                }
+            }
+        }
+
+
 class SSHKeyCredential(Credential):
     """
     SSH key credential

--- a/jenkinsapi/credentials.py
+++ b/jenkinsapi/credentials.py
@@ -11,6 +11,7 @@ except ImportError:
     from urllib.parse import urlencode
 from jenkinsapi.credential import Credential
 from jenkinsapi.credential import UsernamePasswordCredential
+from jenkinsapi.credential import SecretTextCredential
 from jenkinsapi.credential import SSHKeyCredential
 from jenkinsapi.jenkinsbase import JenkinsBase
 from jenkinsapi.custom_exceptions import JenkinsAPIException
@@ -145,6 +146,8 @@ class Credentials(JenkinsBase):
             cr = UsernamePasswordCredential(cred_dict)
         elif cred_dict['typeName'] == 'SSH Username with private key':
             cr = SSHKeyCredential(cred_dict)
+        elif cred_dict['typeName'] == 'Secret text':
+            cr = SecretTextCredential(cred_dict)
         else:
             cr = Credential(cred_dict)
 

--- a/jenkinsapi_tests/systests/__init__.py
+++ b/jenkinsapi_tests/systests/__init__.py
@@ -17,7 +17,8 @@ PLUGIN_DEPENDENCIES = [
     "http://updates.jenkins-ci.org/latest/git-client.hpi",
     "https://updates.jenkins-ci.org/latest/nested-view.hpi",
     "https://updates.jenkins-ci.org/latest/ssh-slaves.hpi",
-    "https://updates.jenkins-ci.org/latest/structs.hpi"
+    "https://updates.jenkins-ci.org/latest/structs.hpi",
+    "http://updates.jenkins-ci.org/latest/plain-credentials.hpi"
 ]
 
 

--- a/jenkinsapi_tests/systests/test_credentials.py
+++ b/jenkinsapi_tests/systests/test_credentials.py
@@ -10,7 +10,8 @@ except ImportError:
 from jenkinsapi_tests.systests.base import BaseSystemTest
 from jenkinsapi_tests.test_utils.random_strings import random_string
 from jenkinsapi.credentials import Credentials
-from jenkinsapi.credential import UsernamePasswordCredential
+from jenkinsapi.credentials import UsernamePasswordCredential
+from jenkinsapi.credentials import SecretTextCredential
 from jenkinsapi.credential import SSHKeyCredential
 from jenkinsapi.custom_exceptions import JenkinsAPIException
 
@@ -122,6 +123,27 @@ class TestCredentials(BaseSystemTest):
         }
         with self.assertRaises(ValueError):
             creds[cred_descr] = SSHKeyCredential(cred_dict)
+
+    def test_create_secret_text_credential(self):
+        """
+        Tests the creation of a secret text.
+        """
+        creds = self.jenkins.credentials
+
+        cred_descr = random_string()
+        cred_dict = {
+            'description': cred_descr,
+            'secret': 'newsecret'
+        }
+        creds[cred_descr] = SecretTextCredential(cred_dict)
+
+        self.assertTrue(cred_descr in creds)
+        cred = creds[cred_descr]
+        self.assertIsInstance(cred, SecretTextCredential)
+        self.assertEquals(cred.secret, None)
+        self.assertEquals(cred.description, cred_descr)
+
+        del creds[cred_descr]
 
     def test_delete_credential(self):
         creds = self.jenkins.credentials

--- a/jenkinsapi_utils/jenkins_launcher.py
+++ b/jenkinsapi_utils/jenkins_launcher.py
@@ -73,6 +73,8 @@ class JenkinsLancher(object):
         if 'JENKINS_HOME' not in os.environ:
             self.jenkins_home = tempfile.mkdtemp(prefix='jenkins-home-')
             os.environ['JENKINS_HOME'] = self.jenkins_home
+        else:
+            self.jenkins_home = os.environ['JENKINS_HOME']
 
         self.jenkins_process = None
         self.q = Queue.Queue()
@@ -99,10 +101,10 @@ class JenkinsLancher(object):
         tarball.extractall(path=self.jenkins_home)
 
     def install_plugins(self):
-        for i, url in enumerate(self.plugin_urls):
-            self.install_plugin(url, i)
+        for url in self.plugin_urls:
+            self.install_plugin(url)
 
-    def install_plugin(self, hpi_url, i):
+    def install_plugin(self, hpi_url):
         plugin_dir = os.path.join(self.jenkins_home, 'plugins')
         if not os.path.exists(plugin_dir):
             os.mkdir(plugin_dir)
@@ -115,6 +117,10 @@ class JenkinsLancher(object):
         with open(plugin_path, 'wb') as h:
             request = requests.get(hpi_url)
             h.write(request.content)
+        # Create an empty .pinned file, so that the downloaded plugin
+        # will be used, instead of the version bundled in jenkins.war
+        # See https://wiki.jenkins-ci.org/display/JENKINS/Pinned+Plugins
+        open(plugin_path + ".pinned", 'a').close()
 
     def stop(self):
         if not self.jenkins_url:


### PR DESCRIPTION
In order to do this, the plain-credentials plugin must be installed.
This requires an update of the bundled credentials plugin, so I
adapted the plugin installation to create an empty .pinned file for
each plugin.

Minor improvements: 
  - set `jenkins_home` in JenkinsLauncher instance if `JENKINS_HOME` env var is defined
  - `JenkinsLancher` -> `JenkinsLauncher`
  - replace enumerate with regular for loop in the `install_plugin` method