### PR TITLE
Add plugin uninstall and install exact versions of plugins

### DIFF
--- a/jenkinsapi/jenkins.py
+++ b/jenkinsapi/jenkins.py
@@ -1,6 +1,10 @@
 """
 Module for jenkinsapi Jenkins object
 """
+
+import json
+import logging
+import time
 try:
     import urlparse
     from urllib import quote as urlquote
@@ -8,8 +12,7 @@ except ImportError:
     # Python3
     import urllib.parse as urlparse
     from urllib.parse import quote as urlquote
-
-import logging
+import requests
 
 from jenkinsapi import config
 from jenkinsapi.credentials import Credentials
@@ -20,10 +23,12 @@ from jenkinsapi.view import View
 from jenkinsapi.label import Label
 from jenkinsapi.nodes import Nodes
 from jenkinsapi.plugins import Plugins
+from jenkinsapi.plugin import Plugin
 from jenkinsapi.views import Views
 from jenkinsapi.queue import Queue
 from jenkinsapi.fingerprint import Fingerprint
 from jenkinsapi.jenkinsbase import JenkinsBase
+from jenkinsapi.utils.jsonp_to_json import jsonp_to_json
 from jenkinsapi.utils.requester import Requester
 from jenkinsapi.custom_exceptions import JenkinsAPIException
 
@@ -56,6 +61,7 @@ class Jenkins(JenkinsBase):
             ssl_verify=ssl_verify)
         self.lazy = lazy
         self.jobs_container = None
+        self.update_center_dict = self._get_update_center_dict()
         JenkinsBase.__init__(self, baseurl, poll=not lazy)
 
     def _poll(self, tree=None):
@@ -330,25 +336,27 @@ class Jenkins(JenkinsBase):
         return '%s/pluginManager/api/python?depth=%i' % (self.baseurl, depth)
 
     def install_plugin(self, plugin):
-        plugin = str(plugin)
-        if '@' not in plugin or len(plugin.split('@')) != 2:
-            usage_err = ('argument must be a string like '
-                         '"plugin-name@version", not "{0}"')
-            usage_err = usage_err.format(plugin)
-            raise ValueError(usage_err)
-        payload = '<jenkins> <install plugin="{0}" /> </jenkins>'
-        payload = payload.format(plugin)
-        url = '%s/pluginManager/installNecessaryPlugins' % (self.baseurl,)
-        return self.requester.post_xml_and_confirm_status(
-            url, data=payload)
+        if not isinstance(plugin, Plugin):
+            plugin = Plugin(plugin)
+        self.plugins[plugin.shortName] = plugin
 
-    def install_plugins(self, plugin_list, restart=False):
-        for plugin in plugin_list:
+    def _get_update_center_dict(self):
+        update_center = 'https://updates.jenkins-ci.org/update-center.json'
+        return json.loads(jsonp_to_json(requests.get(update_center).content))
+
+    def install_plugins(self, plugin_list, restart=False, wait_for_reboot=False):
+        """
+        Install a list of plugins.
+        @param plugin_list: a list of plugins to be installed
+        @param restart:
+        """
+        plugins = [p if isinstance(p, Plugin) else Plugin(p) for p in plugin_list]
+        for plugin in plugins:
             self.install_plugin(plugin)
         if restart:
-            self.safe_restart()
+            self.safe_restart(wait_for_reboot=wait_for_reboot)
 
-    def safe_restart(self):
+    def safe_restart(self, wait_for_reboot=False):
         """ restarts jenkins when no jobs are running """
         # NB: unlike other methods, the value of resp.status_code
         # here can be 503 even when everything is normal
@@ -356,7 +364,32 @@ class Jenkins(JenkinsBase):
         valid = self.requester.VALID_STATUS_CODES + [503]
         resp = self.requester.post_and_confirm_status(url, data='',
                                                       valid=valid)
+        if wait_for_reboot:
+            self._wait_for_reboot()
         return resp
+
+    def _wait_for_reboot(self):
+        wait = 5
+        count = 0
+        max_count = 30
+        success = False
+        while count < max_count:
+            time.sleep(wait)
+            try:
+                self.poll()
+                success = True
+            except (requests.HTTPError, requests.ConnectionError):
+                msg = ("Jenkins has not restarted yet!  (This is"
+                       " try {0} of {1}, waited {2} seconds so far)"
+                       "  Sleeping and trying again..")
+                msg = msg.format(count, max_count, count * wait)
+                log.debug(msg)
+            count += 1
+        if not success:
+            msg = ("Jenkins did not come back from safe restart! "
+                   "Waited {0} seconds altogether.  This "
+                   "failure may cause other failures.")
+            log.critical(msg.format(count * wait))
 
     @property
     def plugins(self):

--- a/jenkinsapi/jenkins.py
+++ b/jenkinsapi/jenkins.py
@@ -354,7 +354,7 @@ class Jenkins(JenkinsBase):
         # NB: unlike other methods, the value of resp.status_code
         # here can be 503 even when everything is normal
         url = '%s/safeRestart' % (self.baseurl,)
-        valid = self.requester.VALID_STATUS_CODES + [503]
+        valid = self.requester.VALID_STATUS_CODES + [503, 500]
         resp = self.requester.post_and_confirm_status(url, data='',
                                                       valid=valid)
         if wait_for_reboot:
@@ -389,7 +389,7 @@ class Jenkins(JenkinsBase):
     def __jenkins_is_unavailable(self):
         while True:
             try:
-                self.requester.get_and_confirm_status(self.baseurl, valid=[503])
+                self.requester.get_and_confirm_status(self.baseurl, valid=[503, 500])
                 return True
             except requests.ConnectionError:
                 # This is also a possibility while Jenkins is restarting

--- a/jenkinsapi/jenkins.py
+++ b/jenkinsapi/jenkins.py
@@ -342,7 +342,8 @@ class Jenkins(JenkinsBase):
 
     def _get_update_center_dict(self):
         update_center = 'https://updates.jenkins-ci.org/update-center.json'
-        return json.loads(jsonp_to_json(requests.get(update_center).content))
+        jsonp = requests.get(update_center).content.decode('utf-8')
+        return json.loads(jsonp_to_json(jsonp))
 
     def install_plugins(self, plugin_list, restart=False, wait_for_reboot=False):
         """

--- a/jenkinsapi/jenkins.py
+++ b/jenkinsapi/jenkins.py
@@ -370,15 +370,18 @@ class Jenkins(JenkinsBase):
         return resp
 
     def _wait_for_reboot(self):
+        # We need to make sure all jobs have finished, and that jenkins is actually restarting.
+        # One way to be sure is to make sure jenkins is really down.
         wait = 5
         count = 0
         max_count = 30
-        success = False
+        self.__jenkins_is_unavailable()  # Blocks until jenkins is really restarting
         while count < max_count:
             time.sleep(wait)
             try:
                 self.poll()
-                success = True
+                len(self.plugins)  # Make sure jenkins is fully started
+                return  # By this time jenkins is back online
             except (requests.HTTPError, requests.ConnectionError):
                 msg = ("Jenkins has not restarted yet!  (This is"
                        " try {0} of {1}, waited {2} seconds so far)"
@@ -386,11 +389,22 @@ class Jenkins(JenkinsBase):
                 msg = msg.format(count, max_count, count * wait)
                 log.debug(msg)
             count += 1
-        if not success:
-            msg = ("Jenkins did not come back from safe restart! "
-                   "Waited {0} seconds altogether.  This "
-                   "failure may cause other failures.")
-            log.critical(msg.format(count * wait))
+        msg = ("Jenkins did not come back from safe restart! "
+               "Waited {0} seconds altogether.  This "
+               "failure may cause other failures.")
+        log.critical(msg.format(count * wait))
+
+    def __jenkins_is_unavailable(self):
+        while True:
+            try:
+                self.requester.get_and_confirm_status(self.baseurl, valid=[503])
+                return True
+            except requests.ConnectionError:
+                # This is also a possibility while Jenkins is restarting
+                return True
+            except requests.HTTPError:
+                # This is a return code that is not 503, so Jenkins is likely available
+                time.sleep(1)
 
     @property
     def plugins(self):

--- a/jenkinsapi/jenkins.py
+++ b/jenkinsapi/jenkins.py
@@ -2,7 +2,6 @@
 Module for jenkinsapi Jenkins object
 """
 
-import json
 import logging
 import time
 try:
@@ -28,7 +27,6 @@ from jenkinsapi.views import Views
 from jenkinsapi.queue import Queue
 from jenkinsapi.fingerprint import Fingerprint
 from jenkinsapi.jenkinsbase import JenkinsBase
-from jenkinsapi.utils.jsonp_to_json import jsonp_to_json
 from jenkinsapi.utils.requester import Requester
 from jenkinsapi.custom_exceptions import JenkinsAPIException
 
@@ -61,7 +59,6 @@ class Jenkins(JenkinsBase):
             ssl_verify=ssl_verify)
         self.lazy = lazy
         self.jobs_container = None
-        self.update_center_dict = self._get_update_center_dict()
         JenkinsBase.__init__(self, baseurl, poll=not lazy)
 
     def _poll(self, tree=None):
@@ -339,11 +336,6 @@ class Jenkins(JenkinsBase):
         if not isinstance(plugin, Plugin):
             plugin = Plugin(plugin)
         self.plugins[plugin.shortName] = plugin
-
-    def _get_update_center_dict(self):
-        update_center = 'https://updates.jenkins-ci.org/update-center.json'
-        jsonp = requests.get(update_center).content.decode('utf-8')
-        return json.loads(jsonp_to_json(jsonp))
 
     def install_plugins(self, plugin_list, restart=False, wait_for_reboot=False):
         """

--- a/jenkinsapi/jenkins.py
+++ b/jenkinsapi/jenkins.py
@@ -339,14 +339,14 @@ class Jenkins(JenkinsBase):
 
     def install_plugins(self, plugin_list, restart=False, wait_for_reboot=False):
         """
-        Install a list of plugins.
-        @param plugin_list: a list of plugins to be installed
-        @param restart:
+        Install a list of plugins and optionally restart jenkins.
+        @param plugin_list: list of plugins to be installed
+        @param restart: Boolean, restart jenkins after plugin installation
         """
         plugins = [p if isinstance(p, Plugin) else Plugin(p) for p in plugin_list]
         for plugin in plugins:
             self.install_plugin(plugin)
-        if restart:
+        if restart and self.plugins.restart_required:
             self.safe_restart(wait_for_reboot=wait_for_reboot)
 
     def safe_restart(self, wait_for_reboot=False):

--- a/jenkinsapi/plugin.py
+++ b/jenkinsapi/plugin.py
@@ -10,8 +10,21 @@ class Plugin(object):
     """
 
     def __init__(self, plugin_dict):
-        assert isinstance(plugin_dict, dict)
-        self.__dict__ = plugin_dict
+        if isinstance(plugin_dict, dict):
+            self.__dict__ = plugin_dict
+        else:
+            self.__dict__ = self.to_plugin(plugin_dict)
+
+    def to_plugin(self, plugin_string):
+        plugin_string = str(plugin_string)
+        if '@' not in plugin_string or len(plugin_string.split('@')) != 2:
+            usage_err = ('plugin specification must be a string like '
+                         '"plugin-name@version", not "{0}"')
+            usage_err = usage_err.format(plugin_string)
+            raise ValueError(usage_err)
+        else:
+            shortName, version = plugin_string.split('@')
+            return {'shortName': shortName, 'version': version}
 
     def __eq__(self, other):
         return self.__dict__ == other.__dict__
@@ -25,3 +38,20 @@ class Plugin(object):
             self.__class__.__name__,
             str(self)
         )
+
+    def get_attributes(self):
+        """
+        Used by Plugins object to install plugins in Jenkins
+        """
+        return "<jenkins> <install plugin=\"%s@%s\" /> </jenkins>" % (self.shortName, self.version)
+
+    def is_latest(self, update_center_dict):
+        if self.version == 'latest':
+            return True
+        center_plugin = update_center_dict['plugins'][self.shortName]
+        return center_plugin['version'] == self.version
+
+    def get_download_link(self, update_center_dict):
+        latest_version = update_center_dict['plugins'][self.shortName]['version']
+        latest_url = update_center_dict['plugins'][self.shortName]['url']
+        return latest_url.replace("/".join((self.shortName, latest_version)), "/".join((self.shortName, self.version)))

--- a/jenkinsapi/plugin.py
+++ b/jenkinsapi/plugin.py
@@ -46,6 +46,11 @@ class Plugin(object):
         return "<jenkins> <install plugin=\"%s@%s\" /> </jenkins>" % (self.shortName, self.version)
 
     def is_latest(self, update_center_dict):
+        """
+        Used by Plugins object to determine if plugin can be
+        installed through the update center (when plugin version is latest version),
+        or must be installed by uploading the plugin hpi file.
+        """
         if self.version == 'latest':
             return True
         center_plugin = update_center_dict['plugins'][self.shortName]

--- a/jenkinsapi/plugins.py
+++ b/jenkinsapi/plugins.py
@@ -4,9 +4,20 @@ jenkinsapi plugins
 from __future__ import print_function
 
 import logging
+import time
+import zipfile
+try:
+    from StringIO import StringIO
+    from urllib import urlencode
+except ImportError:
+    # Python3
+    from io import StringIO
+    from urllib.parse import urlencode
+import requests
 from jenkinsapi.plugin import Plugin
 from jenkinsapi.jenkinsbase import JenkinsBase
 from jenkinsapi.custom_exceptions import UnknownPlugin
+from jenkinsapi.custom_exceptions import JenkinsAPIException
 
 
 log = logging.getLogger(__name__)
@@ -25,6 +36,13 @@ class Plugins(JenkinsBase):
 
     def get_jenkins_obj(self):
         return self.jenkins_obj
+
+    def check_updates_server(self):
+        url = (
+            '%s/pluginManager/checkUpdatesServer'
+            % self.jenkins_obj.baseurl
+        )
+        self.jenkins_obj.requester.post_and_confirm_status(url, params={}, data={})
 
     def _poll(self, tree=None):
         return self.get_data(self.baseurl, tree=tree)
@@ -56,6 +74,86 @@ class Plugins(JenkinsBase):
             return self.get_plugins_dict()[plugin_name]
         except KeyError:
             raise UnknownPlugin(plugin_name)
+
+    def __setitem__(self, shortName, plugin):
+        """
+        Installs plugin in Jenkins.
+
+        If plugin already exists - this method is going to uninstall the existing
+        plugin and install the specified version.
+
+        :param shortName: Plugin ID
+        :param plugin a Plugin object to be installed.
+        """
+        if plugin.is_latest(self.jenkins_obj.update_center_dict):
+            self._install_plugin_from_updatecenter(plugin)
+        else:
+            self._install_specific_version(plugin)
+        self._wait_until_plugin_installed(shortName)
+
+    def _install_plugin_from_updatecenter(self, plugin):
+        """
+        Latest versions of plugins can be installed from the update center (and don't need a restart.)
+        """
+        xml_str = plugin.get_attributes()
+        url = (
+            '%s/pluginManager/installNecessaryPlugins' % self.jenkins_obj.baseurl
+        )
+        self.jenkins_obj.requester.post_xml_and_confirm_status(url, data=xml_str)
+
+    def _install_specific_version(self, plugin):
+        """
+        Plugins that are not the latest version have to be uploaded.
+        """
+        download_link = plugin.get_download_link(update_center_dict=self.jenkins_obj.update_center_dict)
+        downloaded_plugin = StringIO()
+        downloaded_plugin.write(requests.get(download_link).content)
+        self._install_plugin_dependencies(downloaded_plugin)
+        url = ('%s/pluginManager/uploadPlugin' % self.jenkins_obj.baseurl)
+        requester = self.jenkins_obj.requester
+        downloaded_plugin.seek(0)
+        requester.post_and_confirm_status(url, files={'file': ('plugin.hpi', downloaded_plugin)}, data={}, params={})
+
+    def _install_plugin_dependencies(self, downloaded_plugin):
+        with zipfile.ZipFile(downloaded_plugin) as archive:
+            for line in archive.open('META-INF/MANIFEST.MF'):
+                if line.startswith('Plugin-Dependencies: '):
+                    dependencies = line.strip().split('Plugin-Dependencies: ')[1].split(',')
+                    for dep in dependencies:
+                        name, _ = dep.split(':')
+                        # install latest dependency, avoids multiple versions of the same dep
+                        self.jenkins_obj.plugins[name] = Plugin({'shortName': name, 'version': 'latest'})
+
+    def __delitem__(self, shortName):
+        if shortName not in self:
+            raise KeyError(
+                'Plugin with ID "%s" not found, cannot uninstall' % shortName)
+        if self[shortName].deleted:
+            raise JenkinsAPIException('Plugin "%s" already marked for uninstall. '
+                                      'Restart jenkins for uninstall to complete.')
+        params = {
+            'Submit': 'OK',
+            'json': {}
+        }
+        url = ('%s/pluginManager/plugin/%s/doUninstall'
+               % (self.jenkins_obj.baseurl, shortName))
+        self.jenkins_obj.requester.post_and_confirm_status(
+            url, params={}, data=urlencode(params)
+        )
+
+        self.poll()
+        self.plugins = self._data['plugins']
+        if not self[shortName].deleted:
+            raise JenkinsAPIException('Problem uninstalling plugin.')
+
+    def _wait_until_plugin_installed(self, shortName, maxwait=60, interval=1):
+        for time_left in range(maxwait, 0, -interval):
+            self.poll()
+            self.plugins = self._data['plugins']
+            if shortName in self:
+                return
+            time.sleep(interval)
+        raise JenkinsAPIException('Problem installing plugin.')
 
     def __contains__(self, plugin_name):
         """

--- a/jenkinsapi/plugins.py
+++ b/jenkinsapi/plugins.py
@@ -5,7 +5,6 @@ from __future__ import print_function
 
 import logging
 import time
-import zipfile
 try:
     from StringIO import StringIO
     from urllib import urlencode
@@ -20,6 +19,7 @@ from jenkinsapi.jenkinsbase import JenkinsBase
 from jenkinsapi.custom_exceptions import UnknownPlugin
 from jenkinsapi.custom_exceptions import JenkinsAPIException
 from jenkinsapi.utils.jsonp_to_json import jsonp_to_json
+from jenkinsapi.utils.manifest import read_manifest
 
 
 log = logging.getLogger(__name__)
@@ -118,7 +118,20 @@ class Plugins(JenkinsBase):
         """
         url = "%s/updateCenter/installStatus" % self.jenkins_obj.baseurl
         status = self.jenkins_obj.requester.get_url(url)
+        if status.status_code == 404:
+            raise JenkinsAPIException('update_center_install_status not available for Jenkins 1.X')
         return status.json()
+
+    @property
+    def restart_required(self):
+        """
+        Call after plugin installation to check if Jenkins requires a restart
+        """
+        try:
+            jobs = self.update_center_install_status['data']['jobs']
+        except JenkinsAPIException:
+            return True  # Jenkins 1.X has no update_center
+        return any([job for job in jobs if job['requiresRestart'] == 'true'])
 
     def _install_specific_version(self, plugin):
         """
@@ -127,6 +140,7 @@ class Plugins(JenkinsBase):
         download_link = plugin.get_download_link(update_center_dict=self.update_center_dict)
         downloaded_plugin = self._download_plugin(download_link)
         plugin_dependencies = self._get_plugin_dependencies(downloaded_plugin)
+        log.debug("Installing dependencies for plugin '%s'" % plugin.shortName)
         self.jenkins_obj.install_plugins(plugin_dependencies)
         url = ('%s/pluginManager/uploadPlugin' % self.jenkins_obj.baseurl)
         requester = self.jenkins_obj.requester
@@ -138,16 +152,16 @@ class Plugins(JenkinsBase):
         Returns a list of all dependencies for a downloaded plugin
         """
         plugin_dependencies = []
-        for line in self.__get_manifest(downloaded_plugin):
-            line = line.decode('UTF-8')
-            if line.startswith('Plugin-Dependencies: '):
-                dependencies = line.strip().split('Plugin-Dependencies: ')[1].split(',')
-                for dep in dependencies:
-                    components = dep.split(';')  # split plugin:version;resolution:optional entries
-                    dep_plugin = components[0]
-                    name = dep_plugin.split(':')[0]
-                    # install latest dependency, avoids multiple versions of the same dep
-                    plugin_dependencies.append(Plugin({'shortName': name, 'version': 'latest'}))
+        manifest = read_manifest(downloaded_plugin)
+        manifest_dependencies = manifest.main_section.get('Plugin-Dependencies')
+        if manifest_dependencies:
+            dependencies = manifest_dependencies.split(',')
+            for dep in dependencies:
+                components = dep.split(';')  # split plugin:version;resolution:optional entries
+                dep_plugin = components[0]
+                name = dep_plugin.split(':')[0]
+                # install latest dependency, avoids multiple versions of the same dep
+                plugin_dependencies.append(Plugin({'shortName': name, 'version': 'latest'}))
         return plugin_dependencies
 
     def _download_plugin(self, download_link):
@@ -155,33 +169,38 @@ class Plugins(JenkinsBase):
         downloaded_plugin.write(requests.get(download_link).content)
         return downloaded_plugin
 
-    def __get_manifest(self, downloaded_plugin):
-        with zipfile.ZipFile(downloaded_plugin) as archive:
-            return archive.open('META-INF/MANIFEST.MF')
-
     def _plugin_has_finished_installation(self, plugin):
         """
         Return True if installation is marked as 'Success' or 'SuccessButRequiresRestart'
         in Jenkins' update_center, else return False.
         """
-        if self.jenkins_obj.version.startswith('1'):
-            # We have no good way of knowing if a plugin has finished installing.
-            # Most plugins install rapidly, so we return False and the calling method
-            # checks if the plugin has been loaded or the maximum timespan has passed.
-            return False
-        else:
+        try:
             jobs = self.update_center_install_status['data']['jobs']
             for job in jobs:
                 if job['name'] == plugin.shortName and job['installStatus'] in ['Success', 'SuccessButRequiresRestart']:
                     return True
             return False
+        except JenkinsAPIException:
+            return False  # lack of update_center in Jenkins 1.X
+
+    def plugin_version_is_being_installed(self, plugin):
+        """
+        Return true if plugin is currently being installed.
+        """
+        try:
+            jobs = self.update_center_install_status['data']['jobs']
+        except JenkinsAPIException:
+            return False  # lack of update_center in Jenkins 1.X
+        return any([job for job in jobs if job['name'] == plugin.shortName and job['version'] == plugin.version])
 
     def plugin_version_already_installed(self, plugin):
         """
         Check if plugin version is already installed
         """
         if plugin.shortName not in self:
-            return False  # plugin not installed
+            if self.plugin_version_is_being_installed(plugin):
+                return True
+            return False
         installed_plugin = self[plugin.shortName]
         if plugin.version == installed_plugin.version:
             return True

--- a/jenkinsapi/plugins.py
+++ b/jenkinsapi/plugins.py
@@ -144,7 +144,7 @@ class Plugins(JenkinsBase):
 
         self.poll()
         if not self[shortName].deleted:
-            raise JenkinsAPIException('Problem uninstalling plugin.')
+            raise JenkinsAPIException("Problem uninstalling plugin '%s'." % shortName)
 
     def _wait_until_plugin_installed(self, shortName, maxwait=60, interval=1):
         for _ in range(maxwait, 0, -interval):

--- a/jenkinsapi/plugins.py
+++ b/jenkinsapi/plugins.py
@@ -140,7 +140,7 @@ class Plugins(JenkinsBase):
         download_link = plugin.get_download_link(update_center_dict=self.update_center_dict)
         downloaded_plugin = self._download_plugin(download_link)
         plugin_dependencies = self._get_plugin_dependencies(downloaded_plugin)
-        log.debug("Installing dependencies for plugin '%s'" % plugin.shortName)
+        log.debug("Installing dependencies for plugin '%s'", plugin.shortName)
         self.jenkins_obj.install_plugins(plugin_dependencies)
         url = ('%s/pluginManager/uploadPlugin' % self.jenkins_obj.baseurl)
         requester = self.jenkins_obj.requester

--- a/jenkinsapi/utils/jsonp_to_json.py
+++ b/jenkinsapi/utils/jsonp_to_json.py
@@ -1,0 +1,10 @@
+def jsonp_to_json(jsonp):
+    try:
+        l_index = jsonp.index('(') + 1
+        r_index = jsonp.rindex(')')
+    except ValueError:
+        print("Input is not in a jsonp format.")
+        return
+
+    res = jsonp[l_index:r_index]
+    return res

--- a/jenkinsapi/utils/jsonp_to_json.py
+++ b/jenkinsapi/utils/jsonp_to_json.py
@@ -3,8 +3,7 @@ def jsonp_to_json(jsonp):
         l_index = jsonp.index('(') + 1
         r_index = jsonp.rindex(')')
     except ValueError:
-        print("Input is not in a jsonp format.")
+        print("Input is not in jsonp format.")
         return
-
     res = jsonp[l_index:r_index]
     return res

--- a/jenkinsapi/utils/jsonp_to_json.py
+++ b/jenkinsapi/utils/jsonp_to_json.py
@@ -1,3 +1,8 @@
+"""
+Module for converting jsonp to json.
+"""
+
+
 def jsonp_to_json(jsonp):
     try:
         l_index = jsonp.index('(') + 1

--- a/jenkinsapi/utils/manifest.py
+++ b/jenkinsapi/utils/manifest.py
@@ -1,0 +1,92 @@
+"""
+This module enables Manifest file parsing.
+Copied from https://chromium.googlesource.com/external/googleappengine/python/+/master/google/appengine/tools/jarfile.py
+"""
+
+import zipfile
+
+_MANIFEST_NAME = 'META-INF/MANIFEST.MF'
+
+
+class InvalidJarError(Exception):
+    """
+    InvalidJar exception class
+    """
+    pass
+
+
+class Manifest(object):
+    """The parsed manifest from a jar file.
+    Attributes:
+      main_section: a dict representing the main (first) section of the manifest.
+        Each key is a string that is an attribute, such as 'Manifest-Version', and
+        the corresponding value is a string that is the value of the attribute,
+        such as '1.0'.
+      sections: a dict representing the other sections of the manifest. Each key
+        is a string that is the value of the 'Name' attribute for the section,
+        and the corresponding value is a dict like the main_section one, for the
+        other attributes.
+    """
+    def __init__(self, main_section, sections):
+        self.main_section = main_section
+        self.sections = sections
+
+
+def read_manifest(jar_file_name):
+    """Read and parse the manifest out of the given jar.
+    Args:
+      jar_file_name: the name of the jar from which the manifest is to be read.
+    Returns:
+      A parsed Manifest object, or None if the jar has no manifest.
+    Raises:
+      IOError: if the jar does not exist or cannot be read.
+    """
+    with zipfile.ZipFile(jar_file_name) as jar:
+        try:
+            manifest_string = jar.read(_MANIFEST_NAME).decode('UTF-8')
+        except KeyError:
+            return None
+        return _parse_manifest(manifest_string)
+
+
+def _parse_manifest(manifest_string):
+    """Parse a Manifest object out of the given string.
+    Args:
+      manifest_string: a str or unicode that is the manifest contents.
+    Returns:
+      A Manifest object parsed out of the string.
+    Raises:
+      InvalidJarError: if the manifest is not well-formed.
+    """
+    manifest_string = '\n'.join(manifest_string.splitlines()).rstrip('\n')
+    section_strings = manifest_string.split('\n\n')
+    parsed_sections = [_parse_manifest_section(s) for s in section_strings]
+    main_section = parsed_sections[0]
+    sections = dict()
+    try:
+        for entry in parsed_sections[1:]:
+            sections[entry['Name']] = entry
+    except KeyError:
+        raise InvalidJarError('Manifest entry has no Name attribute: %s' % entry)
+    return Manifest(main_section, sections)
+
+
+def _parse_manifest_section(section):
+    """Parse a dict out of the given manifest section string.
+    Args:
+      section: a str or unicode that is the manifest section. It looks something
+        like this (without the >):
+        > Name: section-name
+        > Some-Attribute: some value
+        > Another-Attribute: another value
+    Returns:
+      A dict where the keys are the attributes (here, 'Name', 'Some-Attribute',
+      'Another-Attribute'), and the values are the corresponding attribute values.
+    Raises:
+      InvalidJarError: if the manifest section is not well-formed.
+    """
+    section = section.replace('\n ', '')
+    try:
+        return dict(line.split(': ', 1) for line in section.split('\n'))
+    except ValueError:
+        raise InvalidJarError('Invalid manifest %r' % section)

--- a/jenkinsapi_tests/systests/test_jenkins.py
+++ b/jenkinsapi_tests/systests/test_jenkins.py
@@ -8,7 +8,6 @@ except ImportError:
     import unittest
 from jenkinsapi.job import Job
 from jenkinsapi.jobs import Jobs
-from jenkinsapi.plugin import Plugin
 from jenkinsapi.queue import QueueItem
 from jenkinsapi_tests.systests.base import BaseSystemTest
 from jenkinsapi_tests.systests.job_configs import EMPTY_JOB
@@ -167,20 +166,6 @@ class JobTests(BaseSystemTest):
         master_data = self.jenkins.get_master_data()
         self.assertEquals(master_data['totalExecutors'], 2)
 
-    def test_get_missing_plugin(self):
-        plugins = self.jenkins.get_plugins()
-        with self.assertRaises(KeyError):
-            plugins["lsdajdaslkjdlkasj"]  # this plugin surely does not exist!
-
-    def test_get_single_plugin(self):
-        plugins = self.jenkins.get_plugins()
-        plugin_name, plugin = next(plugins.iteritems())
-        self.assertIsInstance(plugin_name, str)
-        self.assertIsInstance(plugin, Plugin)
-
-    def test_get_single_plugin_depth_2(self):
-        plugins = self.jenkins.get_plugins(depth=2)
-        _, plugin = next(plugins.iteritems())
 
 if __name__ == '__main__':
     unittest.main()

--- a/jenkinsapi_tests/systests/test_plugins.py
+++ b/jenkinsapi_tests/systests/test_plugins.py
@@ -1,0 +1,98 @@
+'''
+System tests for `jenkinsapi.plugins` module.
+'''
+import logging
+# To run unittests on python 2.6 please use unittest2 library
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+import jenkinsapi_tests.systests
+from jenkinsapi_tests.systests.base import BaseSystemTest
+from jenkinsapi_tests.systests.base import DEFAULT_JENKINS_PORT
+from jenkinsapi_tests.test_utils.random_strings import random_string
+from jenkinsapi.jenkins import Jenkins
+from jenkinsapi.plugin import Plugin
+
+log = logging.getLogger(__name__)
+
+
+class TestPlugins(BaseSystemTest):
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            port = jenkinsapi_tests.systests.state['launcher'].http_port
+        except KeyError:
+            log.warning(
+                "Jenkins was not launched from the test-framework, "
+                "assuming port %i" %
+                DEFAULT_JENKINS_PORT)
+            port = DEFAULT_JENKINS_PORT
+        jenkins = Jenkins('http://localhost:%d' % port)
+        plugins = jenkins.plugins
+        plugins.check_updates_server()
+
+    def test_delete_inexistant_plugin(self):
+        with self.assertRaises(KeyError):
+            plugins = self.jenkins.plugins
+
+            del plugins[random_string()]
+
+    def test_install_uninstall_plugin(self):
+        plugins = self.jenkins.plugins
+        plugin_name = 'async-http-client'
+
+        plugin_dict = {
+            'shortName': plugin_name,
+            'version': 'latest',
+        }
+        plugins[plugin_name] = Plugin(plugin_dict)
+
+        self.assertTrue(plugin_name in plugins)
+        plugin = plugins[plugin_name]
+        self.assertIsInstance(plugin, Plugin)
+        self.assertEquals(plugin.shortName, plugin_name)
+
+        del plugins[plugin_name]
+        self.assertTrue(plugins[plugin_name].deleted)
+
+    def test_install_multiple_plugins(self):
+        plugin_one_name = 'jenkins-cloudformation-plugin'
+        plugin_one_version = 'latest'
+        plugin_one = "@".join((plugin_one_name, plugin_one_version))
+        plugin_two = Plugin({'shortName': 'anything-goes-formatter', 'version': 'latest'})
+        self.assertIsInstance(plugin_two, Plugin)
+        plugin_list = [plugin_one, plugin_two]
+        self.jenkins.install_plugins(plugin_list)
+        self.assertIn(plugin_one_name, self.jenkins.plugins)
+        self.assertIn(plugin_two.shortName, self.jenkins.plugins)
+
+    def test_downgrade_plugin(self):
+        plugin_name = 'amazon-ecs'
+        plugin_version = '1.5'
+        plugin = Plugin({'shortName': plugin_name, 'version': plugin_version})
+        self.assertIsInstance(plugin, Plugin)
+        self.jenkins.plugins[plugin_name] = plugin
+        installed_plugin = self.jenkins.plugins[plugin_name]
+        self.assertEquals(installed_plugin.version, '1.5')
+        older_plugin = Plugin({'shortName': plugin_name, 'version': '1.4'})
+        # Need to restart when changing version
+        self.jenkins.install_plugins([older_plugin], restart=True, wait_for_reboot=True)
+        installed_older_plugin = self.jenkins.plugins[plugin_name]
+        self.assertEquals(installed_older_plugin.version, '1.4')
+
+    def test_get_missing_plugin(self):
+        plugins = self.jenkins.get_plugins()
+        with self.assertRaises(KeyError):
+            plugins["lsdajdaslkjdlkasj"]  # this plugin surely does not exist!
+
+    def test_get_single_plugin(self):
+        plugins = self.jenkins.get_plugins()
+        plugin_name, plugin = next(plugins.iteritems())
+        self.assertIsInstance(plugin_name, str)
+        self.assertIsInstance(plugin, Plugin)
+
+    def test_get_single_plugin_depth_2(self):
+        plugins = self.jenkins.get_plugins(depth=2)
+        _, plugin = next(plugins.iteritems())

--- a/jenkinsapi_tests/systests/test_plugins.py
+++ b/jenkinsapi_tests/systests/test_plugins.py
@@ -70,14 +70,14 @@ class TestPlugins(BaseSystemTest):
 
     def test_downgrade_plugin(self):
         plugin_name = 'amazon-ecs'
-        plugin_version = '1.5'
+        plugin_version = '1.5'  # This is explicitly not the latest version
         plugin = Plugin({'shortName': plugin_name, 'version': plugin_version})
         self.assertIsInstance(plugin, Plugin)
-        self.jenkins.plugins[plugin_name] = plugin
+        # Need to restart when not installing the latest version
+        self.jenkins.install_plugins([plugin], restart=True, wait_for_reboot=True)
         installed_plugin = self.jenkins.plugins[plugin_name]
         self.assertEquals(installed_plugin.version, '1.5')
         older_plugin = Plugin({'shortName': plugin_name, 'version': '1.4'})
-        # Need to restart when changing version
         self.jenkins.install_plugins([older_plugin], restart=True, wait_for_reboot=True)
         installed_older_plugin = self.jenkins.plugins[plugin_name]
         self.assertEquals(installed_older_plugin.version, '1.4')

--- a/jenkinsapi_tests/systests/test_restart.py
+++ b/jenkinsapi_tests/systests/test_restart.py
@@ -13,7 +13,6 @@ try:
 except ImportError:
     import unittest
 
-from requests import HTTPError, ConnectionError
 from jenkinsapi_tests.systests.base import BaseSystemTest
 
 log = logging.getLogger(__name__)
@@ -21,40 +20,10 @@ log = logging.getLogger(__name__)
 
 class TestRestart(BaseSystemTest):
 
-    def _wait_for_reboot(self):
-        wait = 5
-        count = 0
-        max_count = 30
-        success = False
-        while count < max_count:
-            time.sleep(wait)
-            try:
-                self.jenkins.poll()
-                success = True
-            except (HTTPError, ConnectionError):
-                msg = ("Jenkins has not restarted yet!  (This is"
-                       " try {0} of {1}, waited {2} seconds so far)"
-                       "  Sleeping and trying again..")
-                msg = msg.format(count, max_count, count*wait)
-                log.debug(msg)
-            count += 1
-        if not success:
-            msg = ("Jenkins did not come back from safe restart! "
-                   "Waited {0} seconds altogether.  This "
-                   "failure may cause other failures.")
-            log.critical(msg.format(count*wait))
-            self.fail("msg")
-
     def test_safe_restart(self):
         self.jenkins.poll()  # jenkins should be alive
-        self.jenkins.safe_restart()
-        with self.assertRaises(HTTPError):
-            # this is a 503: jenkins is still restarting
-            self.jenkins.poll()
-        # the test is now complete, but other tests cannot run until
-        # jenkins has finished restarted.  to avoid cascading failure
-        # we have to wait for reboot to finish.
-        self._wait_for_reboot()
+        self.jenkins.safe_restart(wait_for_reboot=True)
+        self.jenkins.poll()  # This will only succeed on successful reboot
 
 if __name__ == '__main__':
     logging.basicConfig()

--- a/jenkinsapi_tests/unittests/test_plugins.py
+++ b/jenkinsapi_tests/unittests/test_plugins.py
@@ -177,27 +177,36 @@ class TestPlugins(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.J.install_plugin('test')
 
+    @mock.patch.object(Plugins, '_poll')
+    @mock.patch.object(Plugins, '_wait_until_plugin_installed')
     @mock.patch.object(Requester, 'post_xml_and_confirm_status')
-    def test_install_plugin_good_input(self, _post):
-        self.J.install_plugin('test@1.0')
-        expected_data = '<jenkins> <install plugin="test@1.0" /> </jenkins>'
+    def test_install_plugin_good_input(self,_post, _wait, _poll_plugins):
+        _poll_plugins.return_value = self.DATA
+        self.J.install_plugin('test@latest')
+        expected_data = '<jenkins> <install plugin="test@latest" /> </jenkins>'
         _post.assert_called_with(
             '/'.join([self.J.baseurl,
                       'pluginManager',
                       'installNecessaryPlugins']),
             data=expected_data)
 
+    @mock.patch.object(Plugins, '_poll')
+    @mock.patch.object(Plugins, '_wait_until_plugin_installed')
     @mock.patch.object(Requester, 'post_xml_and_confirm_status')
     @mock.patch.object(Jenkins, 'safe_restart')
-    def test_install_plugins_good_input_no_restart(self, _restart, _post):
-        self.J.install_plugins(['test@1.0', 'test@1.0'])
+    def test_install_plugins_good_input_no_restart(self, _restart, _post, _wait, _poll_plugins):
+        _poll_plugins.return_value = self.DATA
+        self.J.install_plugins(['test@latest', 'test@latest'])
         self.assertEqual(_post.call_count, 2)
         self.assertEqual(_restart.call_count, 0)
 
+    @mock.patch.object(Plugins, '_poll')
+    @mock.patch.object(Plugins, '_wait_until_plugin_installed')
     @mock.patch.object(Requester, 'post_xml_and_confirm_status')
     @mock.patch.object(Jenkins, 'safe_restart')
-    def test_install_plugins_good_input_with_restart(self, _restart, _post):
-        self.J.install_plugins(['test@1.0', 'test@1.0'], restart=True)
+    def test_install_plugins_good_input_with_restart(self, _restart, _post, _wait, _poll_plugins):
+        _poll_plugins.return_value = self.DATA
+        self.J.install_plugins(['test@latest', 'test@latest'], restart=True)
         self.assertEqual(_post.call_count, 2)
         self.assertEqual(_restart.call_count, 1)
 

--- a/jenkinsapi_tests/unittests/test_plugins.py
+++ b/jenkinsapi_tests/unittests/test_plugins.py
@@ -183,10 +183,12 @@ class TestPlugins(unittest.TestCase):
             self.J.install_plugin('test')
 
     @mock.patch.object(Plugins, '_poll')
+    @mock.patch.object(Plugins, 'plugin_version_already_installed')
     @mock.patch.object(Plugins, '_wait_until_plugin_installed')
     @mock.patch.object(Requester, 'post_xml_and_confirm_status')
-    def test_install_plugin_good_input(self,_post, _wait, _poll_plugins):
+    def test_install_plugin_good_input(self,_post, _wait, already_installed, _poll_plugins):
         _poll_plugins.return_value = self.DATA
+        already_installed.return_value = False
         self.J.install_plugin('test@latest')
         expected_data = '<jenkins> <install plugin="test@latest" /> </jenkins>'
         _post.assert_called_with(
@@ -196,21 +198,33 @@ class TestPlugins(unittest.TestCase):
             data=expected_data)
 
     @mock.patch.object(Plugins, '_poll')
+    @mock.patch.object(Plugins, 'plugin_version_already_installed')
     @mock.patch.object(Plugins, '_wait_until_plugin_installed')
     @mock.patch.object(Requester, 'post_xml_and_confirm_status')
     @mock.patch.object(Jenkins, 'safe_restart')
-    def test_install_plugins_good_input_no_restart(self, _restart, _post, _wait, _poll_plugins):
+    def test_install_plugins_good_input_no_restart(self, _restart, _post, _wait, already_installed, _poll_plugins):
         _poll_plugins.return_value = self.DATA
+        already_installed.return_value = False
         self.J.install_plugins(['test@latest', 'test@latest'])
         self.assertEqual(_post.call_count, 2)
         self.assertEqual(_restart.call_count, 0)
 
     @mock.patch.object(Plugins, '_poll')
+    @mock.patch.object(Plugins, 'plugin_version_already_installed')
+    @mock.patch.object(Plugins, 'restart_required', new_callable=mock.mock.PropertyMock)
     @mock.patch.object(Plugins, '_wait_until_plugin_installed')
     @mock.patch.object(Requester, 'post_xml_and_confirm_status')
     @mock.patch.object(Jenkins, 'safe_restart')
-    def test_install_plugins_good_input_with_restart(self, _restart, _post, _wait, _poll_plugins):
+    def test_install_plugins_good_input_with_restart(self,
+                                                     _restart,
+                                                     _post,
+                                                     _wait,
+                                                     restart_required,
+                                                     already_installed,
+                                                     _poll_plugins):
         _poll_plugins.return_value = self.DATA
+        restart_required.return_value = True,
+        already_installed.return_value = False
         self.J.install_plugins(['test@latest', 'test@latest'], restart=True)
         self.assertEqual(_post.call_count, 2)
         self.assertEqual(_restart.call_count, 1)
@@ -237,6 +251,28 @@ class TestPlugins(unittest.TestCase):
         self.assertFalse(self.J.plugins.plugin_version_already_installed(not_installed))
         latest = Plugin({'shortName': 'subversion', 'version': 'latest'})
         self.assertFalse(self.J.plugins.plugin_version_already_installed(latest))
+
+    @mock.patch.object(Plugins, '_poll')
+    @mock.patch.object(Plugins, 'update_center_install_status', new_callable=mock.mock.PropertyMock)
+    def test_restart_required_after_plugin_installation(self, status, _poll_plugins):
+        _poll_plugins.return_value = self.DATA
+        status.return_value = {'data': {'jobs': [{'installStatus': 'SuccessButRequiresRestart',
+                                                  'name': 'credentials',
+                                                  'requiresRestart': 'true',
+                                                  'title': None,
+                                                  'version': '0'}],
+                                        'state': 'RUNNING'},
+                               'status': 'ok'}
+        self.assertTrue(self.J.plugins.restart_required)
+
+    @mock.patch.object(Plugins, '_poll')
+    @mock.patch.object(Plugins, 'update_center_install_status', new_callable=mock.mock.PropertyMock)
+    def test_restart_not_required_after_plugin_installation(self, status, _poll_plugins):
+        _poll_plugins.return_value = self.DATA
+        status.return_value = {'data': {'jobs': [],
+                                        'state': 'RUNNING'},
+                               'status': 'ok'}
+        self.assertFalse(self.J.plugins.restart_required)
 
     def test_plugin_repr(self):
         p = Plugin(

--- a/jenkinsapi_tests/unittests/test_plugins.py
+++ b/jenkinsapi_tests/unittests/test_plugins.py
@@ -7,6 +7,11 @@ try:
     import unittest2 as unittest
 except ImportError:
     import unittest
+try:
+    from StringIO import StringIO  # python2
+except ImportError:
+    from io import BytesIO as StringIO  # python3
+import zipfile
 
 from jenkinsapi.jenkins import Requester
 from jenkinsapi.jenkins import Jenkins
@@ -209,6 +214,29 @@ class TestPlugins(unittest.TestCase):
         self.J.install_plugins(['test@latest', 'test@latest'], restart=True)
         self.assertEqual(_post.call_count, 2)
         self.assertEqual(_restart.call_count, 1)
+
+    @mock.patch.object(Plugins, '_poll')
+    def test_get_plugin_dependencies(self, _poll_plugins):
+        manifest = 'Manifest-Version: 1.0\n' \
+                   'bla: somestuff\n' \
+                   'Plugin-Dependencies: aws-java-sdk:1.10.45,aws-credentials:1.15'
+        downloaded_plugin = StringIO()
+        zipfile.ZipFile(downloaded_plugin, mode='w').writestr('META-INF/MANIFEST.MF', manifest)
+        _poll_plugins.return_value = self.DATA
+        dependencies = self.J.plugins._get_plugin_dependencies(downloaded_plugin)
+        self.assertEquals(len(dependencies), 2)
+        for dep in dependencies:
+            self.assertIsInstance(dep, Plugin)
+
+    @mock.patch.object(Plugins, '_poll')
+    def test_plugin_version_already_installed(self, _poll_plugins):
+        _poll_plugins.return_value = self.DATA
+        already_installed = Plugin({'shortName': 'subversion', 'version': '1.45'})
+        self.assertTrue(self.J.plugins.plugin_version_already_installed(already_installed))
+        not_installed = Plugin({'shortName': 'subversion', 'version': '1.46'})
+        self.assertFalse(self.J.plugins.plugin_version_already_installed(not_installed))
+        latest = Plugin({'shortName': 'subversion', 'version': 'latest'})
+        self.assertFalse(self.J.plugins.plugin_version_already_installed(latest))
 
     def test_plugin_repr(self):
         p = Plugin(


### PR DESCRIPTION
Previously, installing plugins would result in a POST to
pluginManager/installNecessaryPlugins, but this endpoint will always
ignore the requested version and install the latest version. Plugin
versions that are not the latest version can only be installed by
uploading the hpi/jpi file for that version.

To get the previous versions' hpi file, the update-center.json file will
be parsed to retrive the download URL for the current version.  The
current version number in the url will then be replaced by the requested
version number. The plugin will be downloaded, unpacked and eventual
dependencies (at their latest version) will be installed.

This commit also introduces the ability to uninstall plugins and adds an
option to wait for reboot (moved from test_restart integration test)
when calling safe_restart().
