### PR TITLE
Fix 'get_build_by_params' method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
 - JENKINS_VERSION=1.x
 - JENKINS_VERSION=2.x
 install:
-- pip install nose mock coverage pep8 "astroid<1.3.0" "pylint<1.4"
+- pip install -r requirements/dev-requirements.txt
 - python setup.py develop
 script:
 - pep8 --ignore=E501 jenkinsapi/*.py

--- a/README.rst
+++ b/README.rst
@@ -130,16 +130,35 @@ the testsuite with the following command:
 
 .. code-block:: bash
 
-        python setup.py test
+    python setup.py test
 
 Otherwise using a virtualenv is recommended. Setuptools will automatically fetch
 missing test dependencies:
 
 .. code-block:: bash
 
-        virtualenv
-        source .venv/bin/active
-        (venv) python setup.py test
+    virtualenv
+    source .venv/bin/active
+    (venv) python setup.py test
+
+Development
+-----------
+
+* Make sure that you have Java_ installed.
+* Create virtual environment for development
+* Install package in development mode
+
+.. code-block:: bash
+
+    (venv) pip install -e .
+    (venv) pip install -r requirements/dev-requirements.txt
+
+* Make your changes, write tests and check your code
+
+.. code-block:: bash
+
+    (venv) nosetests -v jenkinsapi_tests
+
 
 Project Contributors
 --------------------
@@ -155,6 +174,7 @@ Project Contributors
 * Kyle Rockman (kyle.rockman@mac.com)
 * Sascha Peilicke (saschpe@gmx.de)
 * David Johansen (david@makewhat.is)
+* Misha Behersky (bmwant@gmail.com)
 
 Please do not contact these contributors directly for support questions! Use the GitHub tracker instead.
 
@@ -166,3 +186,5 @@ The MIT License (MIT): Permission is hereby granted, free of charge, to any pers
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+.. _Java: http://www.oracle.com/technetwork/java/javase/downloads/jre8-downloads-2133155.html

--- a/jenkinsapi/build.py
+++ b/jenkinsapi/build.py
@@ -98,7 +98,11 @@ class Build(JenkinsBase):
         """
         actions = self._data.get('actions')
         if actions:
-            parameters = actions[0].get('parameters', {})
+            parameters = {}
+            for elem in actions:
+                if 'parameters' in elem:
+                    parameters = elem.get('parameters')
+                    break
             return {pair['name']: pair['value'] for pair in parameters}
 
     def get_changeset_items(self):

--- a/jenkinsapi/build.py
+++ b/jenkinsapi/build.py
@@ -424,12 +424,12 @@ class Build(JenkinsBase):
         return all_actions
 
     def get_causes(self):
-        '''
+        """
         Returns a list of causes. There can be multiple causes lists and
         some of the can be empty. For instance, when a build is manually
         aborted, Jenkins could add an empty causes list to the actions
         dict. Empty ones are ignored.
-        '''
+        """
         all_causes = []
         for dct_action in self._data["actions"]:
             if dct_action is None:
@@ -439,9 +439,9 @@ class Build(JenkinsBase):
         return all_causes
 
     def get_timestamp(self):
-        '''
+        """
         Returns build timestamp in UTC
-        '''
+        """
         # Java timestamps are given in miliseconds since the epoch start!
         naive_timestamp = datetime.datetime(
             *time.gmtime(self._data['timestamp'] / 1000.0)[:6])

--- a/jenkinsapi/build.py
+++ b/jenkinsapi/build.py
@@ -101,7 +101,7 @@ class Build(JenkinsBase):
             parameters = {}
             for elem in actions:
                 if 'parameters' in elem:
-                    parameters = elem.get('parameters')
+                    parameters = elem['parameters']
                     break
             return {pair['name']: pair['value'] for pair in parameters}
 

--- a/jenkinsapi/job.py
+++ b/jenkinsapi/job.py
@@ -306,28 +306,18 @@ class Job(JenkinsBase, MutableJenkinsThing):
     def get_build_by_params(self, build_params, order=1):
         first_build_number = self.get_first_buildnumber()
         last_build_number = self.get_last_buildnumber()
-<<<<<<< HEAD
-        assert order == 1 or order == -1, (
-            'Direction should be ascending or descending (1/-1)'
-        )
+        if order != 1 or order != -1:
+            raise ValueError(
+                'Direction should be ascending or descending (1/-1)')
 
         for number in range(first_build_number,
                             last_build_number + 1)[::order]:
-=======
-        assert order == 1 or order == -1, 'Direction should be ascending or descending (1/-1)'
-
-        for number in range(first_build_number, last_build_number + 1)[::order]:
->>>>>>> 79734ecd6d8bedcf59e6185b94b737601af927df
             build = self.get_build(number)
             if build.get_params() == build_params:
                 return build
 
-<<<<<<< HEAD
         raise NoBuildData(
             'No build with such params {params}'.format(params=build_params))
-=======
-        raise NoBuildData('No build with such params {params}'.format(params=build_params))
->>>>>>> 79734ecd6d8bedcf59e6185b94b737601af927df
 
     def get_revision_dict(self):
         """

--- a/jenkinsapi/job.py
+++ b/jenkinsapi/job.py
@@ -306,7 +306,7 @@ class Job(JenkinsBase, MutableJenkinsThing):
     def get_build_by_params(self, build_params, order=1):
         first_build_number = self.get_first_buildnumber()
         last_build_number = self.get_last_buildnumber()
-        if order != 1 or order != -1:
+        if order != 1 and order != -1:
             raise ValueError(
                 'Direction should be ascending or descending (1/-1)')
 

--- a/jenkinsapi_tests/systests/get-jenkins-war.sh
+++ b/jenkinsapi_tests/systests/get-jenkins-war.sh
@@ -9,4 +9,10 @@ fi
 readonly JENKINS_WAR_URL=$1
 readonly JENKINS_PATH=$2
 
+hash wget 2>/dev/null
+if [ $? -ne 0 ]; then
+    echo "You should install wget to launch tests"
+    exit 1
+fi
+
 wget -O ${JENKINS_PATH}/jenkins.war $JENKINS_WAR_URL

--- a/jenkinsapi_tests/unittests/test_build.py
+++ b/jenkinsapi_tests/unittests/test_build.py
@@ -10,7 +10,7 @@ import datetime
 from jenkinsapi.build import Build
 
 
-class test_build(unittest.TestCase):
+class TestBuildCase(unittest.TestCase):
 
     DATA = {
         'actions': [{'causes': [{'shortDescription': 'Started by user anonymous',
@@ -125,6 +125,36 @@ class test_build(unittest.TestCase):
                     {'name': 'second_param', 'value': 'second_value'},
                 ]
             }]
+        }
+        params = self.b.get_params()
+
+        self.assertDictEqual(params, expected)
+
+    def test_get_params_different_order(self):
+        """
+        Dictionary with `parameters` key is not always the first element in
+        `actions` list, so we need to search through whole array. This test
+        covers such a case
+        """
+        expected = {
+            'first_param': 'first_value',
+            'second_param': 'second_value',
+        }
+        self.b._data = {
+            'actions': [
+                {
+                    'not_parameters': 'some_data',
+                },
+                {
+                    'another_action': 'some_value',
+                },
+                {
+                    'parameters': [
+                        {'name': 'first_param', 'value': 'first_value'},
+                        {'name': 'second_param', 'value': 'second_value'},
+                    ]
+                }
+            ]
         }
         params = self.b.get_params()
 

--- a/jenkinsapi_tests/unittests/test_job.py
+++ b/jenkinsapi_tests/unittests/test_job.py
@@ -363,6 +363,27 @@ class TestJob(unittest.TestCase):
             assert get_params_mock.call_count == 3
             assert result == build_mock
 
+    def test_get_build_by_params_improper_invocation(self):
+        build_params = {
+            'param1': 'value1'
+        }
+        get_params_mock = mock.Mock(side_effect=({}, {}, {}))
+        build_mock = mock.Mock(get_params=get_params_mock)
+        with mock.patch.object(self.j, 'get_first_buildnumber'), \
+                mock.patch.object(self.j, 'get_last_buildnumber'):
+
+            with self.assertRaises(ValueError):
+                self.j.get_build_by_params(build_params, None)
+
+        with mock.patch.object(self.j, 'get_first_buildnumber', return_value=1), \
+                mock.patch.object(self.j, 'get_last_buildnumber', return_value=1), \
+                mock.patch.object(self.j, 'get_build', return_value=build_mock) as get_build_mock:
+
+            with self.assertRaises(NoBuildData):
+                self.j.get_build_by_params(build_params)
+
+            get_build_mock.assert_called_once_with(1)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/requirements/dev-requirements.txt
+++ b/requirements/dev-requirements.txt
@@ -1,0 +1,7 @@
+nose
+mock
+coverage
+pep8
+unittest2
+astroid<1.3.0
+pylint<1.4

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,10 @@ GLOBAL_ENTRY_POINTS = {
     ]
 }
 
+tests_require = [line.strip()
+                 for line in open('requirements/dev-requirements.txt')
+                 if line.strip()]
+
 setup(
     name=PROJECT_NAME.lower(),
     version=REVISION,
@@ -39,7 +43,7 @@ setup(
     include_package_data=False,
     install_requires=['requests>=2.3.0', 'pytz>=2014.4'],
     test_suite='nose.collector',
-    tests_require=['mock', 'nose', 'coverage', 'unittest2'],
+    tests_require=tests_require,
     entry_points=GLOBAL_ENTRY_POINTS,
     url=PROJECT_URL,
     description=SHORT_DESCRIPTION,


### PR DESCRIPTION
## Rationale
Fix for the issue when `parameters` in `actions` list is not the first element and we cannot rely on the order within this array. [Link to discussion](https://github.com/pycontribs/jenkinsapi/pull/488#discussion_r80270130)

## Changes
* Separate test requirements into different file for easier development and updating related files
* Update `readme` with development instructions
* Remove `assert` statement from code as it should *only* be used within tests
* Check for `wget` executable presence as you can launch tests on machine without program installed
* Create additional unittests

Sorry for non-atomic pull request with changes in various places.