### PR TITLE
Allow fn changes on save

### DIFF
--- a/jenkinsapi/artifact.py
+++ b/jenkinsapi/artifact.py
@@ -96,7 +96,7 @@ class Artifact(object):
             local_md5,
             self.build.job.jenkins)
         valid = fp.validate_for_build(
-            os.path.basename(fspath), self.build.job.name, self.build.buildno)
+            self.filename, self.build.job.name, self.build.buildno)
         if not valid or (fp.unknown and strict_validation):
             # strict = 404 as invalid
             raise ArtifactBroken(

--- a/jenkinsapi/build.py
+++ b/jenkinsapi/build.py
@@ -176,31 +176,12 @@ class Build(JenkinsBase):
     def get_duration(self):
         return datetime.timedelta(milliseconds=self._data["duration"])
 
-    def _get_build(self, job_name, buildno, cache):
-        key = (job_name, buildno)
-        if key not in cache:
-            cache[key] = self.get_jenkins_obj()[job_name].get_build(buildno)
-        return cache[key]
-
-    def _get_artifact_builds(self):
-        data = self.poll(tree='fingerprint[fileName,original[name,number]]')
-        build_cache = {(self.job.name, self.buildno): self}
-        builds = {}
-        for fpinfo in data["fingerprint"]:
-            buildno = fpinfo["original"]["number"]
-            job_name = fpinfo["original"]["name"]
-            build = self._get_build(job_name, buildno, build_cache)
-            builds[fpinfo["fileName"]] = build
-        return builds
-
     def get_artifacts(self):
         data = self.poll(tree='artifacts[relativePath,fileName]')
-        builds = self._get_artifact_builds()
         for afinfo in data["artifacts"]:
             url = "%s/artifact/%s" % (self.baseurl,
                                       quote(afinfo["relativePath"]))
-            fn = afinfo["fileName"]
-            af = Artifact(fn, url, builds.get(fn, self),
+            af = Artifact(afinfo["fileName"], url, self,
                           relative_path=afinfo["relativePath"])
             yield af
 

--- a/jenkinsapi_tests/unittests/test_artifact.py
+++ b/jenkinsapi_tests/unittests/test_artifact.py
@@ -44,6 +44,27 @@ def test_verify_download_valid_positive(artifact, monkeypatch):
                                      strict_validation=False)
 
 
+def test_verify_download_valid_positive_with_rename(artifact, monkeypatch):
+    def fake_md5(cls, fspath):   # pylint: disable=unused-argument
+        return '097c42989a9e5d9dcced7b35ec4b0486'
+
+    monkeypatch.setattr(Artifact, '_md5sum', fake_md5)
+
+    def fake_poll(cls, tree=None):   # pylint: disable=unused-argument
+        return {}
+
+    monkeypatch.setattr(JenkinsBase, '_poll', fake_poll)
+
+    def fake_validate(cls, filename,   # pylint: disable=unused-argument
+                      job, build):   # pylint: disable=unused-argument
+        return filename == 'artifact.zip'
+
+    monkeypatch.setattr(Fingerprint, 'validate_for_build', fake_validate)
+
+    assert artifact._verify_download('/tmp/temporary_filename',
+                                     strict_validation=False)
+
+
 def test_verify_download_valid_negative(artifact, monkeypatch):
     def fake_md5(cls, fspath):   # pylint: disable=unused-argument
         return '097c42989a9e5d9dcced7b35ec4b0486'


### PR DESCRIPTION
I found a bit of a bug in #511. If the original build no longer exists, you can't fetch it and error out when trying to get the build number. Instead, I looked more into why my builds failed validation. It turns out it's because I was saving them with a different filename than the one in Jenkins. I'm not sure why this only failed for artifacts from other builds, but the fix seems fairly straightforward. We should simply not validate the filename because there's no reason to do that. Instead, I validate the artifact's filename because we probably do want to make sure we're validating against the right object.

I also reverted #511 in this pull request, as it creates a worse bug than it was trying to fix.

As well as the added unit test, I tried this with my Jenkins and it allowed me to save files that I was unable to save before or after #511.