### PR TITLE
Add get_env_vars to Build

### DIFF
--- a/jenkinsapi/build.py
+++ b/jenkinsapi/build.py
@@ -24,6 +24,7 @@ from jenkinsapi.custom_exceptions import NoResults
 from jenkinsapi.custom_exceptions import JenkinsAPIException
 
 from six.moves.urllib.parse import quote
+from requests import HTTPError
 
 
 log = logging.getLogger(__name__)
@@ -480,3 +481,19 @@ class Build(JenkinsBase):
                 url, data='', valid=[302, 200, 500, ])
             return True
         return False
+
+    def get_env_vars(self):
+        """
+        Return the environment variables.
+
+        This method is using the Environment Injector plugin:
+        https://wiki.jenkins-ci.org/display/JENKINS/EnvInject+Plugin
+        """
+        url = self.python_api_url('%s/injectedEnvVars' % self.baseurl)
+        try:
+            data = self.get_data(url, params={'depth': self.depth})
+        except HTTPError as ex:
+            warnings.warn('Make sure the Environment Injector plugin '
+                          'is installed.')
+            raise ex
+        return data['envMap']

--- a/jenkinsapi_tests/systests/conftest.py
+++ b/jenkinsapi_tests/systests/conftest.py
@@ -25,7 +25,8 @@ PLUGIN_DEPENDENCIES = [
     "https://updates.jenkins-ci.org/latest/nested-view.hpi",
     "https://updates.jenkins-ci.org/latest/ssh-slaves.hpi",
     "https://updates.jenkins-ci.org/latest/structs.hpi",
-    "http://updates.jenkins-ci.org/latest/plain-credentials.hpi"
+    "http://updates.jenkins-ci.org/latest/plain-credentials.hpi",
+    "http://updates.jenkins-ci.org/latest/envinject.hpi"
 ]
 
 

--- a/jenkinsapi_tests/systests/job_configs.py
+++ b/jenkinsapi_tests/systests/job_configs.py
@@ -311,3 +311,31 @@ JOB_WITH_FILE_AND_PARAMS = """
   </publishers>
   <buildWrappers/>
 </project>""".strip()
+
+JOB_WITH_ENV_VARS = '''\
+<?xml version="1.0" encoding="UTF-8"?><project>
+  <actions/>
+  <description/>
+  <keepDependencies>false</keepDependencies>
+  <properties/>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers class="vector"/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders/>
+  <publishers/>
+  <buildWrappers>
+    <EnvInjectBuildWrapper plugin="envinject@1.93.1">
+      <info>
+        <groovyScriptContent>
+          return [\'key1\': \'value1\', \'key2\': \'value2\']
+        </groovyScriptContent>
+        <loadFilesFromMaster>false</loadFilesFromMaster>
+      </info>
+    </EnvInjectBuildWrapper>
+  </buildWrappers>
+</project>
+'''.strip()

--- a/jenkinsapi_tests/systests/test_env_vars.py
+++ b/jenkinsapi_tests/systests/test_env_vars.py
@@ -1,0 +1,17 @@
+"""
+System tests for `jenkinsapi.jenkins` module.
+"""
+from jenkinsapi_tests.systests.job_configs import JOB_WITH_ENV_VARS
+from jenkinsapi_tests.test_utils.random_strings import random_string
+
+
+def test_get_env_vars(jenkins):
+    job_name = 'get_env_vars_create1_%s' % random_string()
+    job = jenkins.create_job(job_name, JOB_WITH_ENV_VARS)
+    job.invoke(block=True)
+    build = job.get_last_build()
+    while build.is_running():
+        time.sleep(0.25)
+    data = build.get_env_vars()
+    assert data['key1'] == 'value1'
+    assert data['key2'] == 'value2'

--- a/jenkinsapi_tests/unittests/configs.py
+++ b/jenkinsapi_tests/unittests/configs.py
@@ -205,3 +205,8 @@ BUILD_SCM_DATA = {
     'timestamp': 1372553675652,
     'url': 'http://localhost:8080/job/git_yssrtigfds/3/'
 }
+
+BUILD_ENV_VARS = {
+    '_class': 'org.jenkinsci.plugins.envinject.EnvInjectVarList',
+    'envMap': {'KEY': 'VALUE'}
+}


### PR DESCRIPTION
The build environment varialbes can be obtained from Jenkins thanks to the EnvInject plugin:
https://wiki.jenkins-ci.org/display/JENKINS/EnvInject+Plugin

To support that in JenkinsAPI the get_env_vars method was added to the Build class.

closes #489 