### PR TITLE
Add support for jobs in folders.

### DIFF
--- a/jenkinsapi/artifact.py
+++ b/jenkinsapi/artifact.py
@@ -96,7 +96,7 @@ class Artifact(object):
             local_md5,
             self.build.job.jenkins)
         valid = fp.validate_for_build(
-            self.filename, self.build.job.name, self.build.buildno)
+            self.filename, self.build.job.get_full_name(), self.build.buildno)
         if not valid or (fp.unknown and strict_validation):
             # strict = 404 as invalid
             raise ArtifactBroken(

--- a/jenkinsapi/job.py
+++ b/jenkinsapi/job.py
@@ -716,3 +716,19 @@ class Job(JenkinsBase, MutableJenkinsThing):
             if build.get_parameters() == build_params:
                 return True
         return False
+
+    @staticmethod
+    def get_full_name_from_url_and_baseurl(url, baseurl):
+        """
+        Get the full name for a job (including parent folders) from the job URL.
+        """
+        path = url.replace(baseurl, '')
+        split = path.split('/')
+        split = [urlparse.unquote(part) for part in split[::2] if part]
+        return '/'.join(split)
+
+    def get_full_name(self):
+        """
+        Get the full name for a job (including parent folders) from the job URL.
+        """
+        return Job.get_full_name_from_url_and_baseurl(self.url, self.jenkins.baseurl)

--- a/jenkinsapi/jobs.py
+++ b/jenkinsapi/jobs.py
@@ -79,7 +79,8 @@ class Jobs(object):
     def __getitem__(self, job_name):
         if job_name in self:
             job_data = [job_row for job_row in self._data
-                        if job_row['name'] == job_name][0]
+                        if job_row['name'] == job_name or
+                        Job.get_full_name_from_url_and_baseurl(job_row['url'], self.jenkins.baseurl) == job_name][0]
             return Job(job_data['url'], job_data['name'], self.jenkins)
         else:
             raise UnknownJob(job_name)
@@ -90,6 +91,8 @@ class Jobs(object):
         """
         for job in self.itervalues():
             yield job.name, job
+            if job.name != job.get_full_name():
+                yield job.get_full_name(), job
 
     def __contains__(self, job_name):
         """
@@ -105,6 +108,8 @@ class Jobs(object):
             self._data = self.poll().get('jobs', [])
         for row in self._data:
             yield row['name']
+            if row['name'] != Job.get_full_name_from_url_and_baseurl(row['url'], self.jenkins.baseurl):
+                yield Job.get_full_name_from_url_and_baseurl(row['url'], self.jenkins.baseurl)
 
     def itervalues(self):
         """

--- a/jenkinsapi_tests/unittests/test_jenkins.py
+++ b/jenkinsapi_tests/unittests/test_jenkins.py
@@ -11,10 +11,10 @@ DATA = {}
 TWO_JOBS_DATA = {
     'jobs': [
         {'name': 'job_one',
-         'url': 'http://localhost:8080/job_one',
+         'url': 'http://localhost:8080/job/job_one',
          'color': 'blue'},
         {'name': 'job_two',
-         'url': 'http://localhost:8080/job_two',
+         'url': 'http://localhost:8080/job/job_two',
          'color': 'blue'},
     ]
 }


### PR DESCRIPTION
I recently ran in to the need to build and download the artifacts of a job in a folder. I ran in to the issues mentioned in #358 and #537.

This pull request allows for referencing jobs by their full path (`folder/job`). It keeps the old `job` references too to avoid breaking any existing scripts.

There may well be other places in the code with similar issues, but these were the ones I ran into first. I hope this helps people who have had similar problems.