### PR TITLE
Dropped support of Jenkins 1.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ python:
 env:
 - JENKINS_VERSION=1.x
 - JENKINS_VERSION=2.x
+jdk:
+- oraclejdk8
 install:
 - pip install -r requirements/dev-requirements.txt
 - python setup.py develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: required
+dist: trusty
 language: python
 python:
 - '2.7'
@@ -6,8 +8,8 @@ python:
 env:
 - JENKINS_VERSION=1.x
 - JENKINS_VERSION=2.x
-jdk:
-- oraclejdk8
+before_install:
+- jdk_switcher use oraclejdk8
 install:
 - pip install -r requirements/dev-requirements.txt
 - python setup.py develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ python:
 - '3.4'
 - '3.5'
 env:
-- JENKINS_VERSION=1.x
-- JENKINS_VERSION=2.x
+- JENKINS_VERSION=stable
+- JENKINS_VERSION=latest
 before_install:
 - jdk_switcher use oraclejdk8
 install:
@@ -17,4 +17,4 @@ script:
 - make lint
 - make coverage
 after_success:
-   - codecov
+- codecov

--- a/jenkinsapi_tests/systests/test_crumbs_requester.py
+++ b/jenkinsapi_tests/systests/test_crumbs_requester.py
@@ -58,6 +58,8 @@ DISABLE_CRUMBS_CONFIG = {
 }
 
 JENKINS2_SSHD_SETTINGS = {
+    'jenkins-security-s2m-MasterKillSwitchConfiguration': {
+    },
     'org-jenkinsci-main-modules-sshd-SSHD': {
         'port': {
             'value': '',
@@ -66,6 +68,14 @@ JENKINS2_SSHD_SETTINGS = {
     },
     'jenkins-CLI': {
         'enabled': False
+    },
+    # This is not required if envinject plugin is not installed
+    # but since it is installed for test suite - we must have this config
+    # If this is not present - Jenkins will return error
+    'org-jenkinsci-plugins-envinject-EnvInjectPluginConfiguration': {
+        'enablePermissions': False,
+        'hideInjectedVars': False,
+        'enableLoadingFromMaster': False
     }
 }
 

--- a/jenkinsapi_tests/systests/test_crumbs_requester.py
+++ b/jenkinsapi_tests/systests/test_crumbs_requester.py
@@ -1,4 +1,3 @@
-import os
 import time
 import json
 import logging
@@ -17,11 +16,6 @@ log = logging.getLogger(__name__)
 DEFAULT_JENKINS_PORT = 8080
 
 ENABLE_CRUMBS_CONFIG = {
-    '': '0',
-    'markupFormatter': {
-        'stapler-class': 'hudson.markup.EscapedMarkupFormatter',
-        '$class': 'hudson.markup.EscapedMarkupFormatter'
-    },
     'hudson-security-csrf-GlobalCrumbIssuerConfiguration': {
         'csrf': {
             'issuer': {
@@ -31,33 +25,19 @@ ENABLE_CRUMBS_CONFIG = {
                 'excludeClientIPFromCrumb': False
             }
         }
-    },
-    'jenkins-model-DownloadSettings': {
-        'useBrowser': False
-    },
-    'org-jenkinsci-main-modules-sshd-SSHD': {
-        'port': {
-            'value': '',
-            'type': 'random'
-        }
-    },
-    'core:apply': ''
+    }
 }
 
 DISABLE_CRUMBS_CONFIG = {
+    'hudson-security-csrf-GlobalCrumbIssuerConfiguration': {},
+}
+
+SECURITY_SETTINGS = {
     '': '0',
     'markupFormatter': {
         'stapler-class': 'hudson.markup.EscapedMarkupFormatter',
         '$class': 'hudson.markup.EscapedMarkupFormatter'
     },
-    'hudson-security-csrf-GlobalCrumbIssuerConfiguration': {},
-    'jenkins-model-DownloadSettings': {
-        'useBrowser': False
-    },
-    'core:apply': ''
-}
-
-JENKINS2_SSHD_SETTINGS = {
     'jenkins-security-s2m-MasterKillSwitchConfiguration': {
     },
     'org-jenkinsci-main-modules-sshd-SSHD': {
@@ -76,15 +56,24 @@ JENKINS2_SSHD_SETTINGS = {
         'enablePermissions': False,
         'hideInjectedVars': False,
         'enableLoadingFromMaster': False
-    }
+    },
+    'jenkins-model-DownloadSettings': {
+        'useBrowser': False
+    },
+    'org-jenkinsci-main-modules-sshd-SSHD': {
+        'port': {
+            'value': '',
+            'type': 'random'
+        }
+    },
+    'core:apply': ''
 }
 
 
 @pytest.fixture(scope='function')
 def crumbed_jenkins(jenkins):
-    if '2.x' in os.environ.get('JENKINS_VERSION', '1.x'):
-        ENABLE_CRUMBS_CONFIG.update(JENKINS2_SSHD_SETTINGS)
-        DISABLE_CRUMBS_CONFIG.update(JENKINS2_SSHD_SETTINGS)
+    ENABLE_CRUMBS_CONFIG.update(SECURITY_SETTINGS)
+    DISABLE_CRUMBS_CONFIG.update(SECURITY_SETTINGS)
 
     jenkins.requester.post_and_confirm_status(
         urljoin(jenkins.baseurl, '/configureSecurity/configure'),
@@ -99,6 +88,7 @@ def crumbed_jenkins(jenkins):
         jenkins.baseurl,
         requester=CrumbRequester(baseurl=jenkins.baseurl)
     )
+
     yield crumbed
 
     crumbed.requester.post_and_confirm_status(

--- a/jenkinsapi_tests/systests/test_crumbs_requester.py
+++ b/jenkinsapi_tests/systests/test_crumbs_requester.py
@@ -63,8 +63,12 @@ JENKINS2_SSHD_SETTINGS = {
             'value': '',
             'type': 'random'
         }
+    },
+    'jenkins-CLI': {
+        'enabled': False
     }
 }
+
 
 @pytest.fixture(scope='function')
 def crumbed_jenkins(jenkins):

--- a/jenkinsapi_utils/jenkins_launcher.py
+++ b/jenkinsapi_utils/jenkins_launcher.py
@@ -1,6 +1,5 @@
 import os
 import time
-import random
 import shutil
 import logging
 import datetime
@@ -96,9 +95,9 @@ class JenkinsLancher(object):
         self.jenkins_process = None
         self.queue = queue.Queue()
         self.plugin_urls = plugin_urls or []
-        if os.environ.get('JENKINS_VERSION', '1.x') == '1.x':
+        if os.environ.get('JENKINS_VERSION', 'stable') == 'stable':
             self.JENKINS_WAR_URL = (
-                'http://mirrors.jenkins-ci.org/war-stable/1.651.3/jenkins.war'
+                'http://mirrors.jenkins-ci.org/war-stable/latest/jenkins.war'
             )
 
     def update_war(self):


### PR DESCRIPTION
The code should work with 1.x version, but may break in future.

Main reason for dropping 1.x is that for tests we use latest versions of plugins and they may be incompatible with old Jenkins. This could be handled by downloading specific versions of all plugins, but I have no time for such effort.

Thus release 0.3.4 was the last release which was tested with Jenkins 1.x

Instead of testing against Jenkins 1.x we will test against LTS (stable) and latest Jenkins versions.

This PR also changes how project is built in Travis - we need to use JDK8 (or, at least, guarantee that specific JDK version is in use). 