### PR TITLE
Add support for AWS Credentials

### DIFF
--- a/jenkinsapi/credential.py
+++ b/jenkinsapi/credential.py
@@ -259,10 +259,10 @@ class AmazonWebServicesCredentials(Credential):
     def __init__(self, cred_dict):
         super(AmazonWebServicesCredentials, self).__init__(cred_dict)
 
-        self.accessKey = cred_dict['accessKey']
-        self.secretKey = cred_dict['secretKey']
-        self.iamRoleArn = cred_dict.get('iamRoleArn', '')
-        self.iamMfaSerialNumber = cred_dict.get('iamMfaSerialNumber', '')
+        self.access_key = cred_dict['accessKey']
+        self.secret_key = cred_dict['secretKey']
+        self.iam_role_arn = cred_dict.get('iamRoleArn', '')
+        self.iam_mfa_serial_number = cred_dict.get('iamMfaSerialNumber', '')
 
     def get_attributes(self):
         """
@@ -282,10 +282,10 @@ class AmazonWebServicesCredentials(Credential):
                     'stapler-class': c_class,
                     '$class': c_class,
                     'id': c_id,
-                    'accessKey': self.accessKey,
-                    'secretKey': self.secretKey,
-                    'iamRoleArn': self.iamRoleArn,
-                    'iamMfaSerialNumber': self.iamMfaSerialNumber,
+                    'accessKey': self.access_key,
+                    'secretKey': self.secret_key,
+                    'iamRoleArn': self.iam_role_arn,
+                    'iamMfaSerialNumber': self.iam_mfa_serial_number,
                     'description': self.description
                 }
             }

--- a/jenkinsapi/credential.py
+++ b/jenkinsapi/credential.py
@@ -234,3 +234,59 @@ class SSHKeyCredential(Credential):
                 }
             }
         }
+
+
+class AmazonWebServicesCredentials(Credential):
+    """
+    AWS credential using the CloudBees AWS Credentials Plugin
+    See https://wiki.jenkins.io/display/JENKINS/CloudBees+AWS+Credentials+Plugin
+
+    Constructor expects following dict:
+        {
+            'credential_id': str,   Automatically set by jenkinsapi
+            'displayName': str,     Automatically set by Jenkins
+            'fullName': str,        Automatically set by Jenkins
+            'description': str,
+            'accessKey': str,
+            'secretKey': str,
+            'iamRoleArn': str,
+            'iamMfaSerialNumber': str
+        }
+
+    When creating credential via jenkinsapi automatic fields not need to be in
+    dict
+    """
+    def __init__(self, cred_dict):
+        super(AmazonWebServicesCredentials, self).__init__(cred_dict)
+
+        self.accessKey = cred_dict['accessKey']
+        self.secretKey = cred_dict['secretKey']
+        self.iamRoleArn = cred_dict.get('iamRoleArn', '')
+        self.iamMfaSerialNumber = cred_dict.get('iamMfaSerialNumber', '')
+
+    def get_attributes(self):
+        """
+        Used by Credentials object to create credential in Jenkins
+        """
+        c_class = (
+            'com.cloudbees.jenkins.plugins.awscredentials.'
+            'AWSCredentialsImpl'
+        )
+        c_id = '' if self.credential_id is None else self.credential_id
+        return {
+            'stapler-class': c_class,
+            'Submit': 'OK',
+            'json': {
+                '': '1',
+                'credentials': {
+                    'stapler-class': c_class,
+                    '$class': c_class,
+                    'id': c_id,
+                    'accessKey': self.accessKey,
+                    'secretKey': self.secretKey,
+                    'iamRoleArn': self.iamRoleArn,
+                    'iamMfaSerialNumber': self.iamMfaSerialNumber,
+                    'description': self.description
+                }
+            }
+        }


### PR DESCRIPTION
Ability to create AWS Credentials.

Example:
```
import jenkinsapi
from jenkinsapi.jenkins import Jenkins
from jenkinsapi.credential import AmazonWebServicesCredentials

J = Jenkins("http://localhost:8080", "username", "password")
creds = J.credentials

desc = "Test new credential"
new_aws_cred = {
    "description": desc,
    "accessKey": "MyAccessKey",
    "secretKey": "MyAwesomeSecretKeyIsAwesome"
}
new_cred = AmazonWebServicesCredentials(new_aws_cred)
creds[desc] = new_cred
```

You need the [CloudBees AWS Credentials Plugin](https://wiki.jenkins.io/display/JENKINS/CloudBees+AWS+Credentials+Plugin)