### PR TITLE
Fixes pycontribs/jenkinsapi#530.

### DIFF
--- a/jenkinsapi/queue.py
+++ b/jenkinsapi/queue.py
@@ -64,7 +64,7 @@ class Queue(JenkinsBase):
 
     def _get_queue_items_for_job(self, job_name):
         for item in self._data["items"]:
-            if item['task']['name'] == job_name:
+            if 'name' in item['task'] and item['task']['name'] == job_name:
                 yield QueueItem(self.get_queue_item_url(item),
                                 jenkins_obj=self.jenkins)
 


### PR DESCRIPTION
It's possible for queued tasks to be unnamed. This is the case when using Pipeline jobs. Check that tasks have names before referring to it.