### PR TITLE
Close #583: Handle parameters with secret values

### DIFF
--- a/jenkinsapi/build.py
+++ b/jenkinsapi/build.py
@@ -106,7 +106,7 @@ class Build(JenkinsBase):
                 if elem.get('_class') == 'hudson.model.ParametersAction':
                     parameters = elem.get('parameters', {})
                     break
-            return {pair['name']: pair['value'] for pair in parameters}
+            return {pair['name']: pair.get('value') for pair in parameters}
 
     def get_changeset_items(self):
         """

--- a/jenkinsapi_tests/unittests/test_build.py
+++ b/jenkinsapi_tests/unittests/test_build.py
@@ -157,6 +157,25 @@ def test_only_ParametersAction_parameters_considered(build):
     assert params == expected
 
 
+def test_ParametersWithNoValueSetValueNone_issue_583(build):
+    """SecretParameters don't share their value in the API."""
+    expected = {
+        'some-secret': None,
+    }
+    build._data = {
+        'actions': [
+            {
+                '_class': 'hudson.model.ParametersAction',
+                'parameters': [
+                    {'name': 'some-secret'},
+                ]
+            }
+        ]
+    }
+    params = build.get_params()
+    assert params == expected
+
+
 def test_build_env_vars(monkeypatch, build):
     def fake_get_data(cls, tree=None, params=None):
         return configs.BUILD_ENV_VARS

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ usedevelop=
 commands=
   python -m pylint jenkinsapi
   python -m pycodestyle
-  py.test -sv --cov=jenkinsapi --cov-report=term-missing --cov-report=xml jenkinsapi_tests
+  py.test -sv --cov=jenkinsapi --cov-report=term-missing --cov-report=xml jenkinsapi_tests {posargs}
 
 [testenv:args]
 deps = -rtest-requirements.txt


### PR DESCRIPTION
Also permit passing extra params to py.test (e.g. -k testname) for
faster iterations.