### PR TITLE
Add csrf header to requester.get_post_url since jenkins had enabled c…

### DIFF
--- a/jenkinsapi/jenkins.py
+++ b/jenkinsapi/jenkins.py
@@ -58,6 +58,8 @@ class Jenkins(JenkinsBase):
         self.lazy = lazy
         self.jobs_container = None
         JenkinsBase.__init__(self, baseurl, poll=not lazy)
+        self.csrf_header = self.get_csrf_header()
+        self.requester.update_csrf_header(self.csrf_header)
 
     def _poll(self, tree=None):
         url = self.python_api_url(self.baseurl)
@@ -450,6 +452,14 @@ class Jenkins(JenkinsBase):
     @property
     def credentials_by_id(self):
         return self.get_credentials(CredentialsById)
+
+    def get_csrf_header(self,csrf_path="crumbIssuer/api/python"):
+        response = self.requester.get_and_confirm_status("%s/%s" %(self.baseurl,csrf_path))
+        import json
+        token = json.loads(response.text)
+        header_name = token['crumbRequestField']
+        header_content = token['crumb']
+        return {header_name:header_content}
 
     def shutdown(self):
         url = "%s/exit" % self.baseurl

--- a/jenkinsapi/jenkins.py
+++ b/jenkinsapi/jenkins.py
@@ -453,13 +453,14 @@ class Jenkins(JenkinsBase):
     def credentials_by_id(self):
         return self.get_credentials(CredentialsById)
 
-    def get_csrf_header(self,csrf_path="crumbIssuer/api/python"):
-        response = self.requester.get_and_confirm_status("%s/%s" %(self.baseurl,csrf_path))
+    def get_csrf_header(self, csrf_path="crumbIssuer/api/python"):
+        response = self.requester.get_and_confirm_status(
+            "%s/%s" % (self.baseurl, csrf_path))
         import json
         token = json.loads(response.text)
         header_name = token['crumbRequestField']
         header_content = token['crumb']
-        return {header_name:header_content}
+        return {header_name: header_content}
 
     def shutdown(self):
         url = "%s/exit" % self.baseurl

--- a/jenkinsapi/utils/requester.py
+++ b/jenkinsapi/utils/requester.py
@@ -52,6 +52,9 @@ class Requester(object):
         self.ssl_verify = ssl_verify
         self.timeout = timeout
 
+    def update_csrf_header(self,header=None):
+        self.csrf_header = header
+
     def get_request_dict(
             self, params=None, data=None, files=None, headers=None, **kwargs):
         requestKwargs = kwargs
@@ -119,6 +122,10 @@ class Requester(object):
             headers=headers,
             allow_redirects=allow_redirects,
             **kwargs)
+        if not headers:
+            headers = self.csrf_header
+        else:
+            headers = headers.update(self.csrf_header)
         return requests.post(self._update_url_scheme(url), **requestKwargs)
 
     def post_xml_and_confirm_status(

--- a/jenkinsapi/utils/requester.py
+++ b/jenkinsapi/utils/requester.py
@@ -51,8 +51,9 @@ class Requester(object):
         self.password = password
         self.ssl_verify = ssl_verify
         self.timeout = timeout
+        self.csrf_header = None
 
-    def update_csrf_header(self,header=None):
+    def update_csrf_header(self, header=None):
         self.csrf_header = header
 
     def get_request_dict(


### PR DESCRIPTION
…srf protection by default


Ah..
I found this was already support later via crump_request. But could you set this as a default option .Or it's not so friendly and easy to get wrong for the quickstart via excamples. 