### PR TITLE
Added new Node methods for wrapping monitor queries

### DIFF
--- a/jenkinsapi/node.py
+++ b/jenkinsapi/node.py
@@ -374,3 +374,101 @@ class Node(JenkinsBase):
         self._et.find(el_name).text = value
         xml_str = ET.tostring(self._et)
         self.upload_config(xml_str)
+
+    def get_monitor(self, monitor_name, poll_monitor=True):
+        """
+        Polls the node returning one of the monitors in the monitorData branch of the
+        returned node api tree.
+        """
+        monitor_data_key = 'monitorData'
+        if poll_monitor:
+            # polling as monitors like response time can be updated
+            monitor_data = self.poll(tree=monitor_data_key)[monitor_data_key]
+        else:
+            monitor_data = self._data[monitor_data_key]
+
+        full_monitor_name = 'hudson.node_monitors.{0}'.format(monitor_name)
+        print monitor_data
+        print full_monitor_name
+        if full_monitor_name not in monitor_data:
+            raise AssertionError('Node monitor %s not found' % monitor_name)
+
+        return monitor_data[full_monitor_name]
+
+    def get_available_physical_memory(self):
+        """
+        Returns the node's available physical memory in bytes.
+        """
+        monitor_data = self.get_monitor('SwapSpaceMonitor')
+        return monitor_data['availablePhysicalMemory']
+
+    def get_available_swap_space(self):
+        """
+        Returns the node's available swap space in bytes.
+        """
+        monitor_data = self.get_monitor('SwapSpaceMonitor')
+        return monitor_data['availableSwapSpace']
+
+    def get_total_physical_memory(self):
+        """
+        Returns the node's total physical memory in bytes.
+        """
+        monitor_data = self.get_monitor('SwapSpaceMonitor')
+        return monitor_data['totalPhysicalMemory']
+
+    def get_total_swap_space(self):
+        """
+        Returns the node's total swap space in bytes.
+        """
+        monitor_data = self.get_monitor('SwapSpaceMonitor')
+        return monitor_data['totalSwapSpace']
+
+    def get_workspace_path(self):
+        """
+        Returns the local path to the node's Jenkins workspace directory.
+        """
+        monitor_data = self.get_monitor('DiskSpaceMonitor')
+        return monitor_data['path']
+
+    def get_workspace_size(self):
+        """
+        Returns the size in bytes of the node's Jenkins workspace directory.
+        """
+        monitor_data = self.get_monitor('DiskSpaceMonitor')
+        return monitor_data['size']
+
+    def get_temp_path(self):
+        """
+        Returns the local path to the node's temp directory.
+        """
+        monitor_data = self.get_monitor('TemporarySpaceMonitor')
+        return monitor_data['path']
+
+    def get_temp_size(self):
+        """
+        Returns the size in bytes of the node's temp directory.
+        """
+        monitor_data = self.get_monitor('TemporarySpaceMonitor')
+        return monitor_data['size']
+
+    def get_architecture(self):
+        """
+        Returns the system architecture of the node eg. "Linux (amd64)".
+        """
+        # no need to poll as the architecture will never change
+        return self.get_monitor('ArchitectureMonitor', poll_monitor=False)
+
+    def get_response_time(self):
+        """
+        Returns the node's average response time.
+        """
+        monitor_data = self.get_monitor('ResponseTimeMonitor')
+        return monitor_data['average']
+
+    def get_clock_difference(self):
+        """
+        Returns the difference between the node's clock and the master Jenkins clock.
+        Used to detect out of sync clocks.
+        """
+        monitor_data = self.get_monitor('ClockMonitor')
+        return monitor_data['diff']

--- a/jenkinsapi_tests/unittests/test_node.py
+++ b/jenkinsapi_tests/unittests/test_node.py
@@ -62,3 +62,68 @@ def test_name(node):
 
 def test_online(node):
     assert node.is_online() is True
+
+
+def test_available_physical_memory(node):
+    monitor = DATA['monitorData']['hudson.node_monitors.SwapSpaceMonitor']
+    expected_value = monitor['availablePhysicalMemory']
+    assert node.get_available_physical_memory() == expected_value
+
+
+def test_available_swap_space(node):
+    monitor = DATA['monitorData']['hudson.node_monitors.SwapSpaceMonitor']
+    expected_value = monitor['availableSwapSpace']
+    assert node.get_available_swap_space() == expected_value
+
+
+def test_total_physical_memory(node):
+    monitor = DATA['monitorData']['hudson.node_monitors.SwapSpaceMonitor']
+    expected_value = monitor['totalPhysicalMemory']
+    assert node.get_total_physical_memory() == expected_value
+
+
+def test_total_swap_space(node):
+    monitor = DATA['monitorData']['hudson.node_monitors.SwapSpaceMonitor']
+    expected_value = monitor['totalSwapSpace']
+    assert node.get_total_swap_space() == expected_value
+
+
+def test_workspace_path(node):
+    monitor = DATA['monitorData']['hudson.node_monitors.DiskSpaceMonitor']
+    expected_value = monitor['path']
+    assert node.get_workspace_path() == expected_value
+
+
+def test_workspace_size(node):
+    monitor = DATA['monitorData']['hudson.node_monitors.DiskSpaceMonitor']
+    expected_value = monitor['size']
+    assert node.get_workspace_size() == expected_value
+
+
+def test_temp_path(node):
+    monitor = DATA['monitorData']['hudson.node_monitors.TemporarySpaceMonitor']
+    expected_value = monitor['path']
+    assert node.get_temp_path() == expected_value
+
+
+def test_temp_size(node):
+    monitor = DATA['monitorData']['hudson.node_monitors.TemporarySpaceMonitor']
+    expected_value = monitor['size']
+    assert node.get_temp_size() == expected_value
+
+
+def test_architecture(node):
+    expected_value = DATA['monitorData']['hudson.node_monitors.ArchitectureMonitor']
+    assert node.get_architecture() == expected_value
+
+
+def test_response_time(node):
+    monitor = DATA['monitorData']['hudson.node_monitors.ResponseTimeMonitor']
+    expected_value = monitor['average']
+    assert node.get_response_time() == expected_value
+
+
+def test_clock_difference(node):
+    monitor = DATA['monitorData']['hudson.node_monitors.ClockMonitor']
+    expected_value = monitor['diff']
+    assert node.get_clock_difference() == expected_value


### PR DESCRIPTION
Added methods to `Node` for querying information stored in the monitor's section of the api tree.

These allow the querying of:
-  The node's available and total physical memory.
-  The node's available and total swap space.
-  The local path of the node's workspace area.
-  The size of the node's workspace area.
-  The local path of the node's temporary area.
-  The size of the node's temporary area.
-  The node's architecture (eg. "Linux").
-  The node's average response time.
-  The clock difference between the node and the Jenkins master.