### PR TITLE
Add support for client side certificates, closes #632

### DIFF
--- a/jenkinsapi/jenkins.py
+++ b/jenkinsapi/jenkins.py
@@ -39,7 +39,7 @@ class Jenkins(JenkinsBase):
             self, baseurl,
             username=None, password=None,
             requester=None, lazy=False,
-            ssl_verify=True, timeout=10):
+            ssl_verify=True, cert=None, timeout=10):
         """
         :param baseurl: baseurl for jenkins instance including port, str
         :param username: username for jenkins auth, str
@@ -53,6 +53,7 @@ class Jenkins(JenkinsBase):
             password,
             baseurl=baseurl,
             ssl_verify=ssl_verify,
+            cert=cert,
             timeout=timeout
         )
         self.requester.timeout = timeout

--- a/jenkinsapi/utils/requester.py
+++ b/jenkinsapi/utils/requester.py
@@ -40,7 +40,7 @@ class Requester(object):
 
     def __init__(
             self, username=None, password=None,
-            ssl_verify=True, baseurl=None,
+            ssl_verify=True, cert=None, baseurl=None,
             timeout=10):
         if username:
             assert password, 'Cannot set a username without a password!'
@@ -50,6 +50,7 @@ class Requester(object):
         self.username = username
         self.password = password
         self.ssl_verify = ssl_verify
+        self.cert = cert
         self.timeout = timeout
 
     def get_request_dict(
@@ -70,6 +71,7 @@ class Requester(object):
             requestKwargs['headers'] = headers
 
         requestKwargs['verify'] = self.ssl_verify
+        requestKwargs['cert'] = self.cert
 
         if data:
             # It may seem odd, but some Jenkins operations require posting


### PR DESCRIPTION
Add "cert" parameter to the Jenkins class init() that is passed down to requests library call arguments.

Reference:
http://docs.python-requests.org/en/master/api/

> cert -- (optional) if String, path to ssl client cert file (.pem). If Tuple, ('cert', 'key') pair.