### PR TITLE
Changing to  *args and **kwargs in requester init. Fixing TypeError bug

### DIFF
--- a/jenkinsapi/jenkins.py
+++ b/jenkinsapi/jenkins.py
@@ -49,8 +49,8 @@ class Jenkins(JenkinsBase):
         self.username = username
         self.password = password
         self.requester = requester or Requester(
-            username=username,
-            password=password,
+            username,
+            password,
             baseurl=baseurl,
             ssl_verify=ssl_verify,
             cert=cert,

--- a/jenkinsapi/jenkins.py
+++ b/jenkinsapi/jenkins.py
@@ -49,8 +49,8 @@ class Jenkins(JenkinsBase):
         self.username = username
         self.password = password
         self.requester = requester or Requester(
-            username,
-            password,
+            username=username,
+            password=password,
             baseurl=baseurl,
             ssl_verify=ssl_verify,
             cert=cert,

--- a/jenkinsapi/utils/requester.py
+++ b/jenkinsapi/utils/requester.py
@@ -41,13 +41,13 @@ class Requester(object):
     def __init__(self, *args, **kwargs):
 
         if args:
-            username, password = args
+            try:
+                username, password = args
+            except ValueError:
+                'Cannot set a username without a password!'
         else:
             username = None
             password = None
-
-        if username:
-            assert password, 'Cannot set a username without a password!'
 
         baseurl = kwargs.get('baseurl', None)
         self.base_scheme = urlparse.urlsplit(

--- a/jenkinsapi/utils/requester.py
+++ b/jenkinsapi/utils/requester.py
@@ -49,7 +49,6 @@ class Requester(object):
             username = None
             password = None
 
-
         baseurl = kwargs.get('baseurl', None)
         self.base_scheme = urlparse.urlsplit(
             baseurl).scheme if baseurl else None

--- a/jenkinsapi/utils/requester.py
+++ b/jenkinsapi/utils/requester.py
@@ -39,19 +39,21 @@ class Requester(object):
     VALID_STATUS_CODES = [200, ]
 
     def __init__(
-            self, username=None, password=None,
-            ssl_verify=True, cert=None, baseurl=None,
-            timeout=10):
-        if username:
-            assert password, 'Cannot set a username without a password!'
+#            self, username=None, password=None,
+#            ssl_verify=True, cert=None, baseurl=None,
+#            timeout=10):
+         self, *args, **kwargs):
+        if kwargs.get('username', None):
+            assert kwargs.get('password', None), 'Cannot set a username without a password!'
 
+        baseurl = kwargs.get('baseurl', None)
         self.base_scheme = urlparse.urlsplit(
-            baseurl).scheme if baseurl else None
-        self.username = username
-        self.password = password
-        self.ssl_verify = ssl_verify
-        self.cert = cert
-        self.timeout = timeout
+                baseurl).scheme if baseurl else None
+        self.username = kwargs.get('username', None)
+        self.password = kwargs.get('password', None)
+        self.ssl_verify = kwargs.get('ssl_verify', True)
+        self.cert = kwargs.get('cert', None)
+        self.timeout = kwargs.get('timeout', 10)
 
     def get_request_dict(
             self, params=None, data=None, files=None, headers=None, **kwargs):

--- a/jenkinsapi/utils/requester.py
+++ b/jenkinsapi/utils/requester.py
@@ -44,7 +44,7 @@ class Requester(object):
             try:
                 username, password = args
             except ValueError as Error:
-                print Error.message
+                print(Error.message)
                 raise Error
         else:
             username = None

--- a/jenkinsapi/utils/requester.py
+++ b/jenkinsapi/utils/requester.py
@@ -49,6 +49,7 @@ class Requester(object):
             username = None
             password = None
 
+
         baseurl = kwargs.get('baseurl', None)
         self.base_scheme = urlparse.urlsplit(
             baseurl).scheme if baseurl else None

--- a/jenkinsapi/utils/requester.py
+++ b/jenkinsapi/utils/requester.py
@@ -43,9 +43,9 @@ class Requester(object):
         if args:
             try:
                 username, password = args
-            except ValueError as e:
-                print e.message
-                raise e
+            except ValueError as Error:
+                print Error.message
+                raise Error
         else:
             username = None
             password = None

--- a/jenkinsapi/utils/requester.py
+++ b/jenkinsapi/utils/requester.py
@@ -44,7 +44,6 @@ class Requester(object):
             try:
                 username, password = args
             except ValueError as Error:
-                print(Error.message)
                 raise Error
         else:
             username = None

--- a/jenkinsapi/utils/requester.py
+++ b/jenkinsapi/utils/requester.py
@@ -44,7 +44,7 @@ class Requester(object):
             try:
                 username, password = args
             except ValueError:
-                'Cannot set a username without a password!'
+                raise AssertionError('Cannot set a username without a password!')
         else:
             username = None
             password = None

--- a/jenkinsapi/utils/requester.py
+++ b/jenkinsapi/utils/requester.py
@@ -38,17 +38,13 @@ class Requester(object):
 
     VALID_STATUS_CODES = [200, ]
 
-    def __init__(
-#            self, username=None, password=None,
-#            ssl_verify=True, cert=None, baseurl=None,
-#            timeout=10):
-         self, *args, **kwargs):
+    def __init__(self, **kwargs):
         if kwargs.get('username', None):
             assert kwargs.get('password', None), 'Cannot set a username without a password!'
 
         baseurl = kwargs.get('baseurl', None)
         self.base_scheme = urlparse.urlsplit(
-                baseurl).scheme if baseurl else None
+            baseurl).scheme if baseurl else None
         self.username = kwargs.get('username', None)
         self.password = kwargs.get('password', None)
         self.ssl_verify = kwargs.get('ssl_verify', True)

--- a/jenkinsapi/utils/requester.py
+++ b/jenkinsapi/utils/requester.py
@@ -38,15 +38,18 @@ class Requester(object):
 
     VALID_STATUS_CODES = [200, ]
 
-    def __init__(self, **kwargs):
-        if kwargs.get('username', None):
-            assert kwargs.get('password', None), 'Cannot set a username without a password!'
+    def __init__(self, *args, **kwargs):
+
+        username, password = args
+
+        if username:
+            assert password, 'Cannot set a username without a password!'
 
         baseurl = kwargs.get('baseurl', None)
         self.base_scheme = urlparse.urlsplit(
             baseurl).scheme if baseurl else None
-        self.username = kwargs.get('username', None)
-        self.password = kwargs.get('password', None)
+        self.username = username
+        self.password = password
         self.ssl_verify = kwargs.get('ssl_verify', True)
         self.cert = kwargs.get('cert', None)
         self.timeout = kwargs.get('timeout', 10)

--- a/jenkinsapi/utils/requester.py
+++ b/jenkinsapi/utils/requester.py
@@ -40,7 +40,11 @@ class Requester(object):
 
     def __init__(self, *args, **kwargs):
 
-        username, password = args
+        if args:
+            username, password = args
+        else:
+            username = None
+            password = None
 
         if username:
             assert password, 'Cannot set a username without a password!'

--- a/jenkinsapi/utils/requester.py
+++ b/jenkinsapi/utils/requester.py
@@ -43,8 +43,9 @@ class Requester(object):
         if args:
             try:
                 username, password = args
-            except ValueError:
-                raise AssertionError('Cannot set a username without a password!')
+            except ValueError as e:
+                print e.message
+                raise e
         else:
             username = None
             password = None


### PR DESCRIPTION
The current krb_requester has a bug that spits out `TypeError`:

Sample code to reproduce
```
from jenkinsapi.utils.krb_requester import KrbRequester
import requests_kerberos
from jenkinsapi.jenkins import Jenkins
jenkins_url = <some_jenkins_url>
jobname = 'somejob'
requester = KrbRequester(baseurl=jenkins_url, mutual_auth=requests_kerberos.OPTIONAL)
myjenkins = Jenkins(jenkins_url, requester=requester)
job = myjenkins.get_job(jobname)
last_stable_build = job.get_last_stable_build()
print('last stable build slave is:')
print last_stable_build.get_slave()```

Error:
```Traceback (most recent call last):
  File "krb_test.py", line 9, in <module>
    requester = KrbRequester(baseurl='someurl', mutual_auth=requests_kerberos.OPTIONAL)
  File "/Users/foobar/Library/Python/2.7/lib/python/site-packages/jenkinsapi/utils/krb_requester.py", line 25, in __init__
    super(KrbRequester, self).__init__(*args, **kwargs)
TypeError: __init__() got an unexpected keyword argument 'mutual_auth'```



This is caused by the `mutual_auth` argument in KrbRequester class which gets passed down to the parent Requester class.

This PR fixes that issue.
