### PR TITLE
Flexibility of using a different baseurl instead of url from job

### DIFF
--- a/jenkinsapi/build.py
+++ b/jenkinsapi/build.py
@@ -53,7 +53,9 @@ class Build(JenkinsBase):
         self.buildno = buildno
         self.job = job
         self.depth = depth
-        JenkinsBase.__init__(self, url)
+
+        real_url = JenkinsBase.construct_url(url, job.get_jenkins_obj())
+        JenkinsBase.__init__(self, real_url)
 
     def _poll(self, tree=None):
         # For build's we need more information for downstream and

--- a/jenkinsapi/jenkins.py
+++ b/jenkinsapi/jenkins.py
@@ -39,11 +39,17 @@ class Jenkins(JenkinsBase):
             self, baseurl,
             username=None, password=None,
             requester=None, lazy=False,
-            ssl_verify=True, cert=None, timeout=10):
+            ssl_verify=True, cert=None, timeout=10, use_baseurl=False):
         """
         :param baseurl: baseurl for jenkins instance including port, str
         :param username: username for jenkins auth, str
         :param password: password for jenkins auth, str
+        :param requester: , Requester
+        :param lazy: delay polling of data, bool
+        :param ssl_verify: requests lib Verify SSL (See requests lib), bool.
+        :param cert: requests lib certificate (See requests lib), String or tuple.
+        :param timeout: requests lib timeout (See requests lib), float or tuple.
+        :param use_baseurl: If jenkins baseurl is diff from job url, use jenkins baseurl, bool.
         :return: a Jenkins obj
         """
         self.username = username
@@ -59,6 +65,7 @@ class Jenkins(JenkinsBase):
         self.requester.timeout = timeout
         self.lazy = lazy
         self.jobs_container = None
+        self.use_baseurl = use_baseurl
         JenkinsBase.__init__(self, baseurl, poll=not lazy)
 
     def _poll(self, tree=None):
@@ -267,6 +274,10 @@ class Jenkins(JenkinsBase):
     def get_queue_url(self):
         url = "%s/%s" % (self.base_server_url(), 'queue')
         return url
+
+    @property
+    def get_use_baseurl(self):
+        return self.use_baseurl
 
     def get_queue(self):
         queue_url = self.get_queue_url()

--- a/jenkinsapi/jenkinsbase.py
+++ b/jenkinsapi/jenkinsbase.py
@@ -7,6 +7,7 @@ import pprint
 import logging
 from jenkinsapi import config
 from jenkinsapi.custom_exceptions import JenkinsAPIException
+from six.moves.urllib.parse import urlparse
 
 
 class JenkinsBase(object):
@@ -124,3 +125,14 @@ class JenkinsBase(object):
             else:
                 fmt = "%s/%s"
             return fmt % (url, config.JENKINS_API)
+
+    @staticmethod
+    def construct_url(jobUrl, jenkinsObj):
+        if jenkinsObj.base_server_url() and jenkinsObj.use_baseurl:
+            build_hostname = urlparse(jobUrl).netloc
+            jenkins_obj_hostname = urlparse(jenkinsObj.base_server_url()).netloc
+            if build_hostname != jenkins_obj_hostname:
+                real_url = jobUrl.replace(build_hostname, jenkins_obj_hostname)
+                return real_url
+
+        return jobUrl

--- a/jenkinsapi/job.py
+++ b/jenkinsapi/job.py
@@ -64,7 +64,8 @@ class Job(JenkinsBase, MutableJenkinsThing):
             'hg': self._get_hg_branch,
             None: lambda element_tree: []
         }
-        self.url = url
+
+        self.url = JenkinsBase.construct_url(url, jenkins_obj)
         JenkinsBase.__init__(self, self.url)
 
     def __str__(self):

--- a/jenkinsapi_tests/conftest.py
+++ b/jenkinsapi_tests/conftest.py
@@ -1,5 +1,16 @@
 import os
 import logging
+from jenkinsapi.jenkins import Jenkins
+
+
+def create_jenkins_object(monkeypatch, jenkins_url, use_baseurl=False):
+    def fake_poll(cls, tree=None):   # pylint: disable=unused-argument
+        return {}
+
+    monkeypatch.setattr(Jenkins, '_poll', fake_poll)
+    new_jenkins = Jenkins(jenkins_url, use_baseurl=use_baseurl)
+
+    return new_jenkins
 
 
 logging.basicConfig(

--- a/jenkinsapi_tests/unittests/test_build_scm_git.py
+++ b/jenkinsapi_tests/unittests/test_build_scm_git.py
@@ -3,11 +3,18 @@ import pytest
 from . import configs
 from jenkinsapi.build import Build
 from jenkinsapi.job import Job
+from jenkinsapi.jenkins import Jenkins
 
 
 @pytest.fixture(scope='function')
-def jenkins(mocker):
-    return mocker.MagicMock()
+def jenkins(monkeypatch):
+    def fake_poll(cls, tree=None):   # pylint: disable=unused-argument
+        return {}
+
+    monkeypatch.setattr(Jenkins, '_poll', fake_poll)
+    fake_jenkins = Jenkins('http://')
+
+    return fake_jenkins
 
 
 @pytest.fixture(scope='function')
@@ -16,7 +23,6 @@ def job(monkeypatch, jenkins):
         return configs.JOB_DATA
 
     monkeypatch.setattr(Job, '_poll', fake_poll)
-
     fake_job = Job('http://', 'Fake_Job', jenkins)
     return fake_job
 

--- a/jenkinsapi_tests/unittests/test_job_get_all_builds.py
+++ b/jenkinsapi_tests/unittests/test_job_get_all_builds.py
@@ -179,6 +179,8 @@ class TestJobGetAllBuilds(unittest.TestCase):
     def setUp(self):
         TestJobGetAllBuilds.__get_data_call_count = 0
         self.J = mock.MagicMock()  # Jenkins object
+        self.J.base_server_url.return_value = ''
+        self.J.get_use_baseurl.return_value = False
         self.j = Job('http://halob:8080/job/foo/', 'foo', self.J)
 
     @mock.patch.object(JenkinsBase, 'get_data', fakeGetDataTree)

--- a/jenkinsapi_tests/unittests/test_job_scm_hg.py
+++ b/jenkinsapi_tests/unittests/test_job_scm_hg.py
@@ -62,6 +62,8 @@ class TestHgJob(unittest.TestCase):
     @mock.patch.object(JenkinsBase, 'get_data', fakeGetData)
     def setUp(self):
         self.J = mock.MagicMock()  # Jenkins object
+        self.J.base_server_url.return_value = ''
+        self.J.get_use_baseurl.return_value = False
         self.j = Job('http://halob:8080/job/foo/', 'foo', self.J)
 
     def configtree_with_branch(self):

--- a/jenkinsapi_tests/unittests/test_view.py
+++ b/jenkinsapi_tests/unittests/test_view.py
@@ -70,6 +70,8 @@ class TestView(unittest.TestCase):
         # def __init__(self, url, name, jenkins_obj)
         self.J = mock.MagicMock()  # Jenkins object
         self.J.has_job.return_value = False
+        self.J.base_server_url.return_value = ''
+        self.J.get_use_baseurl.return_value = False
         self.v = View('http://localhost:800/view/FodFanFo', 'FodFanFo', self.J)
 
     def testRepr(self):


### PR DESCRIPTION
In some setup, the jenkins baseurl might differ from the url configured in the job (global configuration).

This PR is allowing for the flexibility to override the url when instantiating a job or build 