### PR TITLE
Remove unsupported SSH slave types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 dist: trusty
 group: edge
+sudo: false
 language: python
 python:
 - '2.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ before_install:
 install:
 - pip install tox-travis
 - python setup.py -q sdist bdist_wheel
+script:
+- tox
 jobs:
   include:
     - stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python:
 - '3.4'
 - '3.5'
 - '3.6'
-- '3.7'
 env:
 - JENKINS_VERSION=stable
 - JENKINS_VERSION=latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,13 @@ before_install:
 install:
 - pip install tox-travis
 - python setup.py -q sdist bdist_wheel
-script:
-- tox
 jobs:
   include:
+    - stage: test
+      script: tox
     - stage: release
       python: 2.7
+      if: branch = master
       deploy:
         provider: pypi
         user: lechat

--- a/jenkinsapi/credential.py
+++ b/jenkinsapi/credential.py
@@ -193,6 +193,10 @@ class SSHKeyCredential(Credential):
     private_key value is parsed to find type of credential to create:
 
     private_key starts with -       the value is private key itself
+
+    These credential variations are no longer supported by SSH Credentials
+    plugin. jenkinsapi will raise ValueError if they are used:
+
     private_key starts with /       the value is a path to key
     private_key starts with ~       the value is a key from ~/.ssh
 
@@ -216,12 +220,6 @@ class SSHKeyCredential(Credential):
             self.key_value = None
         elif cred_dict['private_key'].startswith('-'):
             self.key_type = 0
-            self.key_value = cred_dict['private_key']
-        elif cred_dict['private_key'].startswith('/'):
-            self.key_type = 1
-            self.key_value = cred_dict['private_key']
-        elif cred_dict['private_key'].startswith('~'):
-            self.key_type = 2
             self.key_value = cred_dict['private_key']
         else:
             raise ValueError('Invalid private_key value')

--- a/jenkinsapi_tests/systests/test_credentials.py
+++ b/jenkinsapi_tests/systests/test_credentials.py
@@ -92,14 +92,8 @@ def test_create_ssh_credential(jenkins):
         'passphrase': '',
         'private_key': '/tmp/key'
     }
-    creds[cred_descr] = SSHKeyCredential(cred_dict)
-
-    assert cred_descr in creds
-    cred = creds[cred_descr]
-    assert isinstance(cred, SSHKeyCredential) is True
-    assert cred.description == cred_descr
-
-    del creds[cred_descr]
+    with pytest.raises(ValueError):
+        creds[cred_descr] = SSHKeyCredential(cred_dict)
 
     cred_dict = {
         'description': cred_descr,
@@ -107,14 +101,8 @@ def test_create_ssh_credential(jenkins):
         'passphrase': '',
         'private_key': '~/.ssh/key'
     }
-    creds[cred_descr] = SSHKeyCredential(cred_dict)
-
-    assert cred_descr in creds
-    cred = creds[cred_descr]
-    assert isinstance(cred, SSHKeyCredential) is True
-    assert cred.description == cred_descr
-
-    del creds[cred_descr]
+    with pytest.raises(ValueError):
+        creds[cred_descr] = SSHKeyCredential(cred_dict)
 
     cred_dict = {
         'description': cred_descr,

--- a/jenkinsapi_tests/systests/test_nodes.py
+++ b/jenkinsapi_tests/systests/test_nodes.py
@@ -60,7 +60,7 @@ def test_create_ssh_node(jenkins):
         'description': cred_descr,
         'userName': 'username',
         'passphrase': '',
-        'private_key': '~'
+        'private_key': '-----BEGIN RSA PRIVATE KEY-----'
     }
     creds[cred_descr] = SSHKeyCredential(cred_dict)
     node_dict = {
@@ -182,5 +182,8 @@ def test_set_master_executors(jenkins):
     node = jenkins.nodes['master']
 
     assert node.get_num_executors() == 2
+
     node.set_num_executors(5)
     assert node.get_num_executors() == 5
+
+    node.set_num_executors(2)

--- a/pylintrc
+++ b/pylintrc
@@ -51,7 +51,7 @@ load-plugins=
 # E1103: %s %r has no %r member (but some types could not be inferred) - fails to infer real members of types, e.g. in Celery
 # W0231: method from base class is not called - complains about not invoking empty __init__s in parents, which is annoying
 # R0921: abstract class not referenced, when in fact referenced from another egg
-disable=F0401,E0611,E1101,W0142,W0212,R0201,W0703,R0801,R0901,W0511,E1103,W0231,R0921,W0402,I0011,wrong-import-position,wrong-import-order,ungrouped-imports,redefined-variable-type,missing-docstring,redefined-outer-name,redefined-builtin,relative-import,c-extension-no-member
+disable=F0401,E0611,E1101,W0142,W0212,R0201,W0703,R0801,R0901,W0511,E1103,W0231,R0921,W0402,I0011,wrong-import-position,wrong-import-order,ungrouped-imports,redefined-variable-type,missing-docstring,redefined-outer-name,redefined-builtin,relative-import,c-extension-no-member,useless-object-inheritance,no-else-return,consider-using-in,consider-using-dict-comprehension
 
 [REPORTS]
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-pytest
+pytest==3.7.0
 pytest-mock
 pytest-cov
 pycodestyle>=2.3.1

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@
 #     $ tox         # lint/tests for both
 #
 [tox]
-envlist = py27,py34,py35
+envlist = py27,py34,py35,py36
 
 [testenv]
 deps=-rtest-requirements.txt


### PR DESCRIPTION
Jenkins SSH Credentials plugin now only supports credential based on private key stored in Jenkins. I removed support of other types and code will throw ValueError for any other ssh key type.