### PR TITLE
Remove ssh credentials no longer supported by ssh credentials plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 dist: trusty
 group: edge
-sudo: false
+sudo: required
 language: python
 python:
 - '2.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 dist: trusty
 group: edge
+sudo: false
 language: python
 python:
 - '2.7'
@@ -18,8 +19,11 @@ script:
 - tox
 jobs:
   include:
+    - stage: test
+      script: tox
     - stage: release
       python: 2.7
+      if: branch = master
       deploy:
         provider: pypi
         user: lechat

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python:
 - '3.4'
 - '3.5'
 - '3.6'
-- '3.7'
 env:
 - JENKINS_VERSION=stable
 - JENKINS_VERSION=latest

--- a/jenkinsapi/credential.py
+++ b/jenkinsapi/credential.py
@@ -193,6 +193,10 @@ class SSHKeyCredential(Credential):
     private_key value is parsed to find type of credential to create:
 
     private_key starts with -       the value is private key itself
+
+    These credential variations are no longer supported by SSH Credentials
+    plugin. jenkinsapi will raise ValueError if they are used:
+
     private_key starts with /       the value is a path to key
     private_key starts with ~       the value is a key from ~/.ssh
 
@@ -216,12 +220,6 @@ class SSHKeyCredential(Credential):
             self.key_value = None
         elif cred_dict['private_key'].startswith('-'):
             self.key_type = 0
-            self.key_value = cred_dict['private_key']
-        elif cred_dict['private_key'].startswith('/'):
-            self.key_type = 1
-            self.key_value = cred_dict['private_key']
-        elif cred_dict['private_key'].startswith('~'):
-            self.key_type = 2
             self.key_value = cred_dict['private_key']
         else:
             raise ValueError('Invalid private_key value')

--- a/jenkinsapi_tests/systests/job_configs.py
+++ b/jenkinsapi_tests/systests/job_configs.py
@@ -37,7 +37,7 @@ LONG_RUNNING_JOB = """
   <concurrentBuild>false</concurrentBuild>
   <builders>
     <hudson.tasks.Shell>
-      <command>ping -c 50 localhost</command>
+      <command>sleep 100</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers/>
@@ -60,7 +60,7 @@ SHORTISH_JOB = """
   <concurrentBuild>false</concurrentBuild>
   <builders>
     <hudson.tasks.Shell>
-      <command>ping -c 5 localhost</command>
+      <command>ping -c 5 127.0.0.1</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers/>
@@ -139,7 +139,7 @@ JOB_WITH_ARTIFACTS = """
   <concurrentBuild>false</concurrentBuild>
   <builders>
     <hudson.tasks.Shell>
-      <command>ping -c 10 localhost | tee out.txt
+      <command>ping -c 10 127.0.0.1 | tee out.txt
 gzip &lt; out.txt &gt; out.gz</command>
     </hudson.tasks.Shell>
   </builders>
@@ -182,7 +182,7 @@ MATRIX_JOB = """
   </axes>
   <builders>
     <hudson.tasks.Shell>
-      <command>ping -c 10 localhost</command>
+      <command>ping -c 10 127.0.0.1</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers/>
@@ -252,7 +252,7 @@ JOB_WITH_PARAMETERS = """
   <concurrentBuild>false</concurrentBuild>
   <builders>
     <hudson.tasks.Shell>
-      <command>ping -c 1 localhost | tee out.txt
+      <command>ping -c 1 127.0.0.1 | tee out.txt
 echo $A &gt; a.txt
 echo $B &gt; b.txt</command>
     </hudson.tasks.Shell>

--- a/jenkinsapi_tests/systests/job_configs.py
+++ b/jenkinsapi_tests/systests/job_configs.py
@@ -139,7 +139,7 @@ JOB_WITH_ARTIFACTS = """
   <concurrentBuild>false</concurrentBuild>
   <builders>
     <hudson.tasks.Shell>
-      <command>ping -c 10 127.0.0.1 | tee out.txt
+      <command>ping -c 10 127.0.0.1 > out.txt
 gzip &lt; out.txt &gt; out.gz</command>
     </hudson.tasks.Shell>
   </builders>

--- a/jenkinsapi_tests/systests/test_credentials.py
+++ b/jenkinsapi_tests/systests/test_credentials.py
@@ -92,14 +92,8 @@ def test_create_ssh_credential(jenkins):
         'passphrase': '',
         'private_key': '/tmp/key'
     }
-    creds[cred_descr] = SSHKeyCredential(cred_dict)
-
-    assert cred_descr in creds
-    cred = creds[cred_descr]
-    assert isinstance(cred, SSHKeyCredential) is True
-    assert cred.description == cred_descr
-
-    del creds[cred_descr]
+    with pytest.raises(ValueError):
+        creds[cred_descr] = SSHKeyCredential(cred_dict)
 
     cred_dict = {
         'description': cred_descr,
@@ -107,14 +101,8 @@ def test_create_ssh_credential(jenkins):
         'passphrase': '',
         'private_key': '~/.ssh/key'
     }
-    creds[cred_descr] = SSHKeyCredential(cred_dict)
-
-    assert cred_descr in creds
-    cred = creds[cred_descr]
-    assert isinstance(cred, SSHKeyCredential) is True
-    assert cred.description == cred_descr
-
-    del creds[cred_descr]
+    with pytest.raises(ValueError):
+        creds[cred_descr] = SSHKeyCredential(cred_dict)
 
     cred_dict = {
         'description': cred_descr,

--- a/jenkinsapi_tests/systests/test_crumbs_requester.py
+++ b/jenkinsapi_tests/systests/test_crumbs_requester.py
@@ -86,6 +86,7 @@ def crumbed_jenkins(jenkins):
         },
         headers={'Content-Type': 'application/x-www-form-urlencoded'}
     )
+    log.info('Enabled Jenkins security')
 
     crumbed = Jenkins(
         jenkins.baseurl,
@@ -102,6 +103,7 @@ def crumbed_jenkins(jenkins):
         },
         headers={'Content-Type': 'application/x-www-form-urlencoded'}
     )
+    log.info('Disabled Jenkins security')
 
 
 def test_invoke_job_with_file(crumbed_jenkins):

--- a/jenkinsapi_tests/systests/test_jenkins_artifacts.py
+++ b/jenkinsapi_tests/systests/test_jenkins_artifacts.py
@@ -2,13 +2,17 @@
 System tests for `jenkinsapi.jenkins` module.
 '''
 import os
+from posixpath import join
 import re
 import time
 import gzip
 import shutil
 import tempfile
+import logging
 from jenkinsapi_tests.systests.job_configs import JOB_WITH_ARTIFACTS
 from jenkinsapi_tests.test_utils.random_strings import random_string
+
+log = logging.getLogger(__name__)
 
 
 def test_artifacts(jenkins):
@@ -32,22 +36,21 @@ def test_artifacts(jenkins):
     try:
         # Verify that we can handle text artifacts
         text_artifact.save_to_dir(tempDir, strict_validation=True)
-        assert os.path.exists(os.path.join(tempDir, text_artifact.filename))
-        readBackText = open(
-            os.path.join(tempDir, text_artifact.filename),
-            'rb').read().strip()
-        readBackText = readBackText.decode('ascii')
-        assert re.match(r'^PING \S+ \(127.0.0.1\)', readBackText) is not None
-        assert readBackText.endswith('ms') is True
+        text_file_path = join(tempDir, text_artifact.filename)
+        assert os.path.exists(text_file_path)
+        read_back_text = open(text_file_path, 'rb').read().strip()
+        read_back_text = read_back_text.decode('ascii')
+        log.info('Text artifact: %s', read_back_text)
+        assert re.match(r'^PING \S+ \(127.0.0.1\)', read_back_text) is not None
+        assert read_back_text.endswith('ms') is True
 
         # Verify that we can hande binary artifacts
         binary_artifact.save_to_dir(tempDir, strict_validation=True)
-        assert os.path.exists(os.path.join(tempDir, binary_artifact.filename))
-        readBackText = gzip.open(
-            os.path.join(tempDir, binary_artifact.filename,),
-            'rb').read().strip()
-        readBackText = readBackText.decode('ascii')
-        assert re.match(r'^PING \S+ \(127.0.0.1\)', readBackText) is not None
-        assert readBackText.endswith('ms') is True
+        bin_file_path = join(tempDir, binary_artifact.filename)
+        assert os.path.exists(bin_file_path)
+        read_back_text = gzip.open(bin_file_path, 'rb').read().strip()
+        read_back_text = read_back_text.decode('ascii')
+        assert re.match(r'^PING \S+ \(127.0.0.1\)', read_back_text) is not None
+        assert read_back_text.endswith('ms') is True
     finally:
         shutil.rmtree(tempDir)

--- a/jenkinsapi_tests/systests/test_nodes.py
+++ b/jenkinsapi_tests/systests/test_nodes.py
@@ -69,7 +69,7 @@ def test_create_ssh_node(jenkins):
         'remote_fs': '/tmp',
         'labels': node_name,
         'exclusive': False,
-        'host': 'localhost',
+        'host': '127.0.0.1',
         'port': 22,
         'credential_description': cred_descr,
         'jvm_options': '',

--- a/jenkinsapi_tests/systests/test_nodes.py
+++ b/jenkinsapi_tests/systests/test_nodes.py
@@ -60,7 +60,7 @@ def test_create_ssh_node(jenkins):
         'description': cred_descr,
         'userName': 'username',
         'passphrase': '',
-        'private_key': '~'
+        'private_key': '-----BEGIN RSA PRIVATE KEY-----'
     }
     creds[cred_descr] = SSHKeyCredential(cred_dict)
     node_dict = {
@@ -182,5 +182,8 @@ def test_set_master_executors(jenkins):
     node = jenkins.nodes['master']
 
     assert node.get_num_executors() == 2
+
     node.set_num_executors(5)
     assert node.get_num_executors() == 5
+
+    node.set_num_executors(2)

--- a/pylintrc
+++ b/pylintrc
@@ -51,7 +51,7 @@ load-plugins=
 # E1103: %s %r has no %r member (but some types could not be inferred) - fails to infer real members of types, e.g. in Celery
 # W0231: method from base class is not called - complains about not invoking empty __init__s in parents, which is annoying
 # R0921: abstract class not referenced, when in fact referenced from another egg
-disable=F0401,E0611,E1101,W0142,W0212,R0201,W0703,R0801,R0901,W0511,E1103,W0231,R0921,W0402,I0011,wrong-import-position,wrong-import-order,ungrouped-imports,redefined-variable-type,missing-docstring,redefined-outer-name,redefined-builtin,relative-import,c-extension-no-member
+disable=F0401,E0611,E1101,W0142,W0212,R0201,W0703,R0801,R0901,W0511,E1103,W0231,R0921,W0402,I0011,wrong-import-position,wrong-import-order,ungrouped-imports,redefined-variable-type,missing-docstring,redefined-outer-name,redefined-builtin,relative-import,c-extension-no-member,useless-object-inheritance,no-else-return,consider-using-in,consider-using-dict-comprehension
 
 [REPORTS]
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-pytest
+pytest==3.7.0
 pytest-mock
 pytest-cov
 pycodestyle>=2.3.1

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@
 #     $ tox         # lint/tests for both
 #
 [tox]
-envlist = py27,py34,py35
+envlist = py27,py34,py35,py36
 
 [testenv]
 deps=-rtest-requirements.txt


### PR DESCRIPTION
Refactored some tests and make sure that build runs on GCE - that's the only way to ensure that build runs w/o intemittent problems.