### PR TITLE
API: add toggle keep build forever

### DIFF
--- a/jenkinsapi/api.py
+++ b/jenkinsapi/api.py
@@ -15,7 +15,6 @@ from jenkinsapi import constants
 from jenkinsapi.jenkins import Jenkins
 from jenkinsapi.artifact import Artifact
 from jenkinsapi.custom_exceptions import ArtifactsMissing, TimeOut, BadURL
-from jenkinsapi.utils.crumb_requester import CrumbRequester
 
 log = logging.getLogger(__name__)
 
@@ -245,14 +244,3 @@ def search_artifact_by_regexp(jenkinsurl, jobid, artifactRegExp,
                 return art
 
     raise ArtifactsMissing()
-
-
-def toggle_keep_build_forever(jenkinsurl, jobname, build_no,
-                              username, password, ssl_verify=True):
-    """
-    Toggles the keep this build forever flag for the specified build.
-    """
-    crumb = CrumbRequester(username, password, baseurl=jenkinsurl,
-                           ssl_verify=ssl_verify)
-    url = "%s/job/%s/%s/toggleLogKeep" % (jenkinsurl, jobname, build_no)
-    crumb.post_url(url)

--- a/jenkinsapi/api.py
+++ b/jenkinsapi/api.py
@@ -15,6 +15,7 @@ from jenkinsapi import constants
 from jenkinsapi.jenkins import Jenkins
 from jenkinsapi.artifact import Artifact
 from jenkinsapi.custom_exceptions import ArtifactsMissing, TimeOut, BadURL
+from jenkinsapi.utils.crumb_requester import CrumbRequester
 
 log = logging.getLogger(__name__)
 
@@ -244,3 +245,14 @@ def search_artifact_by_regexp(jenkinsurl, jobid, artifactRegExp,
                 return art
 
     raise ArtifactsMissing()
+
+
+def toggle_keep_build_forever(jenkinsurl, jobname, build_no,
+                              username=None, password=None, ssl_verify=True):
+    """
+    Toggles the keep this build forever flag for the specified build
+    """
+    crumb = CrumbRequester(username, password, baseurl=jenkinsurl,
+                           ssl_verify=ssl_verify)
+    url = "%s/job/%s/%s/toggleLogKeep" % (jenkinsurl, jobname, build_no)
+    crumb.post_url(url)

--- a/jenkinsapi/api.py
+++ b/jenkinsapi/api.py
@@ -248,9 +248,9 @@ def search_artifact_by_regexp(jenkinsurl, jobid, artifactRegExp,
 
 
 def toggle_keep_build_forever(jenkinsurl, jobname, build_no,
-                              username=None, password=None, ssl_verify=True):
+                              username, password, ssl_verify=True):
     """
-    Toggles the keep this build forever flag for the specified build
+    Toggles the keep this build forever flag for the specified build.
     """
     crumb = CrumbRequester(username, password, baseurl=jenkinsurl,
                            ssl_verify=ssl_verify)

--- a/jenkinsapi/build.py
+++ b/jenkinsapi/build.py
@@ -22,6 +22,7 @@ from jenkinsapi.jenkinsbase import JenkinsBase
 from jenkinsapi.constants import STATUS_SUCCESS
 from jenkinsapi.custom_exceptions import NoResults
 from jenkinsapi.custom_exceptions import JenkinsAPIException
+from jenkinsapi.utils.crumb_requester import CrumbRequester
 
 from six.moves.urllib.parse import quote
 from requests import HTTPError
@@ -531,3 +532,16 @@ class Build(JenkinsBase):
                           'is installed.')
             raise ex
         return data['envMap']
+
+    def toggle_keep_build_forever(self):
+        """
+        Toggles the keep this build forever flag for the specified build.
+        """
+        requester = self.job.jenkins.requester
+        if not isinstance(requester, CrumbRequester):
+            requester = CrumbRequester(requester.username, requester.password,
+                                       baseurl=self.baseurl,
+                                       ssl_verify=requester.ssl_verify)
+        url = "%s/job/%s/%s/toggleLogKeep" % (self.baseurl, self.job.name,
+                                              self.buildno)
+        requester.post_url(url)

--- a/jenkinsapi_tests/unittests/test_build.py
+++ b/jenkinsapi_tests/unittests/test_build.py
@@ -6,7 +6,7 @@ from . import configs
 import datetime
 from jenkinsapi.build import Build
 from jenkinsapi.job import Job
-from jenkinsapi.utils.crumb_requester import CrumbRequester 
+from jenkinsapi.utils.crumb_requester import CrumbRequester
 
 
 @pytest.fixture(scope='function')
@@ -220,6 +220,7 @@ def test_build_env_vars_other_exception(monkeypatch, build):
 
 def test_toggle_keep_build_forever(monkeypatch, build):
     def fake_post_url(cls, url):
+        assert isinstance(cls, CrumbRequester)
         assert url == 'http:/job/Fake_Job/97/toggleLogKeep'
     monkeypatch.setattr(CrumbRequester, 'post_url', fake_post_url)
 

--- a/jenkinsapi_tests/unittests/test_build.py
+++ b/jenkinsapi_tests/unittests/test_build.py
@@ -6,6 +6,7 @@ from . import configs
 import datetime
 from jenkinsapi.build import Build
 from jenkinsapi.job import Job
+from jenkinsapi.utils.crumb_requester import CrumbRequester 
 
 
 @pytest.fixture(scope='function')
@@ -215,3 +216,11 @@ def test_build_env_vars_other_exception(monkeypatch, build):
             build.get_env_vars()
     assert '' == str(excinfo.value)
     assert len(record) == 0
+
+
+def test_toggle_keep_build_forever(monkeypatch, build):
+    def fake_post_url(cls, url):
+        assert url == 'http:/job/Fake_Job/97/toggleLogKeep'
+    monkeypatch.setattr(CrumbRequester, 'post_url', fake_post_url)
+
+    build.toggle_keep_build_forever()


### PR DESCRIPTION
This commit aims to add an API function that allows a user of the
API to toggle the "keep this build forever" flag on the jenkins
build page.

This is related to #645 but does not close it as it's missing the
"edit the build information - display name and description"
part of the summary.

https://github.com/pycontribs/jenkinsapi/issues/645