### PR TITLE
Parameterize war-filename and locally save hpi-files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 /dist
 .settings
 *.DS_Store
-jenkins.war
+localinstance_files/
 .coverage/
 .coverage
 nosetests.xml

--- a/jenkinsapi_tests/systests/conftest.py
+++ b/jenkinsapi_tests/systests/conftest.py
@@ -57,9 +57,12 @@ def _delete_all_credentials(jenkins):
 @pytest.fixture(scope='session')
 def launched_jenkins():
     systests_dir, _ = os.path.split(__file__)
-    war_path = os.path.join(systests_dir, 'jenkins.war')
+    local_orig_dir = os.path.join(systests_dir, 'localinstance_files')
+    if not os.path.exists(local_orig_dir):
+        os.mkdir(local_orig_dir)
+    war_name = 'jenkins.war'
     launcher = JenkinsLancher(
-        war_path, PLUGIN_DEPENDENCIES,
+        local_orig_dir, systests_dir, war_name, PLUGIN_DEPENDENCIES,
         jenkins_url=os.getenv('JENKINS_URL', None)
     )
     launcher.start()

--- a/jenkinsapi_tests/systests/get-jenkins-war.sh
+++ b/jenkinsapi_tests/systests/get-jenkins-war.sh
@@ -1,16 +1,17 @@
 #!/bin/bash
 #JENKINS_WAR_URL="http://mirrors.jenkins-ci.org/war/latest/jenkins.war"
 
-if [[ "$#" -ne 2 ]]; then
-    echo "Usage: $0 jenkins_url path_to_store_jenkins"
+if [[ "$#" -ne 3 ]]; then
+    echo "Usage: $0 jenkins_url path_to_store_jenkins war_filename"
     exit 1
 fi
 
 readonly JENKINS_WAR_URL=$1
 readonly JENKINS_PATH=$2
+readonly WAR_FILENAME=$3
 
-if   [[ $(type -t wget) ]]; then wget -O ${JENKINS_PATH}/jenkins.war $JENKINS_WAR_URL
-elif [[ $(type -t curl) ]]; then curl -sSL -o ${JENKINS_PATH}/jenkins.war $JENKINS_WAR_URL
+if   [[ $(type -t wget) ]]; then wget -O ${JENKINS_PATH}/${WAR_FILENAME} $JENKINS_WAR_URL
+elif [[ $(type -t curl) ]]; then curl -sSL -o ${JENKINS_PATH}/${WAR_FILENAME} $JENKINS_WAR_URL
 else
     echo "Could not find wget or curl"
     exit 1


### PR DESCRIPTION
I noticed the war-file gets saved when downloading, but the hpi get re-downloaded on every test-run. For people with slow internet (like myself on occasions), or a limited amount of bandwidth, I've made sure to also 'cache' the hpi-files.

I also noticed that the first efforts to parameterize the war-filename where done, but not completely finished, so I added that too.