### PR TITLE
Use session id cookie to improve performace

### DIFF
--- a/jenkinsapi/utils/requester.py
+++ b/jenkinsapi/utils/requester.py
@@ -37,6 +37,7 @@ class Requester(object):
     """
 
     VALID_STATUS_CODES = [200, ]
+    AUTH_COOKIE = None
 
     def __init__(self, *args, **kwargs):
 
@@ -93,6 +94,11 @@ class Requester(object):
                 headers, dict), \
                 'headers must be a dict, got %s' % repr(headers)
             requestKwargs['headers'] = headers
+
+        if self.AUTH_COOKIE:
+            currentheaders = requestKwargs.get('headers', {})
+            currentheaders.update({'Cookie': self.AUTH_COOKIE})
+            requestKwargs['headers'] = currentheaders
 
         requestKwargs['verify'] = self.ssl_verify
         requestKwargs['cert'] = self.cert

--- a/jenkinsapi_tests/unittests/test_requester.py
+++ b/jenkinsapi_tests/unittests/test_requester.py
@@ -3,6 +3,7 @@ import pytest
 import requests
 from jenkinsapi.jenkins import Requester
 from jenkinsapi.custom_exceptions import JenkinsAPIException
+from mock import patch
 
 
 def test_no_parameters_uses_default_values():
@@ -125,6 +126,50 @@ def test_get_request_dict_auth():
     assert isinstance(req_return, dict)
     assert req_return.get('auth')
     assert req_return['auth'] == ('foo', 'bar')
+
+
+@patch('jenkinsapi.jenkins.Requester.AUTH_COOKIE', 'FAKE')
+def test_get_request_dict_cookie():
+    req = Requester('foo', 'bar')
+
+    req_return = req.get_request_dict(
+        params={},
+        data=None,
+        headers=None
+    )
+    assert isinstance(req_return, dict)
+    assert req_return.get('headers')
+    assert req_return.get('headers').get('Cookie')
+    assert req_return.get('headers').get('Cookie') == 'FAKE'
+
+
+@patch('jenkinsapi.jenkins.Requester.AUTH_COOKIE', 'FAKE')
+def test_get_request_dict_updatecookie():
+    req = Requester('foo', 'bar')
+
+    req_return = req.get_request_dict(
+        params={},
+        data=None,
+        headers={'key': 'value'}
+    )
+    assert isinstance(req_return, dict)
+    assert req_return.get('headers')
+    assert req_return.get('headers').get('key')
+    assert req_return.get('headers').get('key') == 'value'
+    assert req_return.get('headers').get('Cookie')
+    assert req_return.get('headers').get('Cookie') == 'FAKE'
+
+
+def test_get_request_dict_nocookie():
+    req = Requester('foo', 'bar')
+
+    req_return = req.get_request_dict(
+        params={},
+        data=None,
+        headers=None
+    )
+    assert isinstance(req_return, dict)
+    assert not req_return.get('headers')
 
 
 def test_get_request_dict_wrong_params():


### PR DESCRIPTION
Hello,

This pull request adds a new function use_auth_cookie(). It is used like this:

```python
server = Jenkins(JENKINS_URL, username="user", password="password")
server.use_auth_cookie()
# for example we can look for the jobs now
for job in server.get_jobs():
    print(job)
```

This function will login and get the JSESSIONID cookie in jenkins and will use it every request from this moment on.

Doing that the performance skyrockets. Now the api is too slow because it has to authenticate in every request, and when we have to look for data in hundreds of jobs and builds, the times are just too high. This pull request fixes this issue.

I wrote the code trying to impact the rest of the api as least as possible.

BR.