### PR TITLE
Add new method to create job and use it to speedup QueueItem

### DIFF
--- a/jenkinsapi/jenkins.py
+++ b/jenkinsapi/jenkins.py
@@ -16,6 +16,7 @@ from jenkinsapi.credentials import Credentials2x
 from jenkinsapi.credentials import CredentialsById
 from jenkinsapi.executors import Executors
 from jenkinsapi.jobs import Jobs
+from jenkinsapi.job import Job
 from jenkinsapi.view import View
 from jenkinsapi.label import Label
 from jenkinsapi.nodes import Nodes
@@ -141,6 +142,15 @@ class Jenkins(JenkinsBase):
         :return: Job obj
         """
         return self.jobs[jobname]
+
+    def get_job_by_url(self, url, job_name):
+        """
+        Get a job by url
+        :param url: jobs' url
+        :param jobname: name of the job, str
+        :return: Job obj
+        """
+        return Job(url, job_name, self)
 
     def has_job(self, jobname):
         """

--- a/jenkinsapi/queue.py
+++ b/jenkinsapi/queue.py
@@ -1,11 +1,11 @@
 """
 Queue module for jenkinsapi
 """
+import logging
+import time
 from requests import HTTPError
 from jenkinsapi.jenkinsbase import JenkinsBase
 from jenkinsapi.custom_exceptions import UnknownQueueItem, NotBuiltYet
-import logging
-import time
 
 log = logging.getLogger(__name__)
 
@@ -110,7 +110,10 @@ class QueueItem(JenkinsBase):
         """
         Return the job associated with this queue item
         """
-        return self.jenkins[self._data['task']['name']]
+        return self.jenkins.get_job_by_url(
+            self._data['task']['url'],
+            self._data['task']['name'],
+        )
 
     def get_parameters(self):
         """returns parameters of queue item"""
@@ -131,8 +134,8 @@ class QueueItem(JenkinsBase):
 
     def get_build(self):
         build_number = self.get_build_number()
-        job_name = self.get_job_name()
-        return self.jenkins[job_name][build_number]
+        job = self.get_job()
+        return job[build_number]
 
     def block_until_complete(self, delay=5):
         build = self.block_until_building(delay)


### PR DESCRIPTION
Since QueueItem has full job url, there is no need to find that job by name. We get `Job` object directly because we know that job exists.