### PR TITLE
Fix for build.get_artifacts()

### DIFF
--- a/jenkinsapi/build.py
+++ b/jenkinsapi/build.py
@@ -222,7 +222,7 @@ class Build(JenkinsBase):
 
     def get_artifact_dict(self):
         return dict(
-            (af.filename, af) for af in self.get_artifacts()
+            (af.relative_filename, af) for af in self.get_artifacts()
         )
 
     def get_upstream_job_name(self):

--- a/jenkinsapi/build.py
+++ b/jenkinsapi/build.py
@@ -222,7 +222,7 @@ class Build(JenkinsBase):
 
     def get_artifact_dict(self):
         return dict(
-            (af.relative_filename, af) for af in self.get_artifacts()
+            (af.relative_path, af) for af in self.get_artifacts()
         )
 
     def get_upstream_job_name(self):


### PR DESCRIPTION
* Artifact dictionary returned is indexed by relative_path
  rather than a filename.