### PR TITLE
Fix failures caused by plugins

### DIFF
--- a/jenkinsapi_tests/systests/conftest.py
+++ b/jenkinsapi_tests/systests/conftest.py
@@ -13,30 +13,31 @@ ADMIN_PASSWORD = 'admin'
 
 # Extra plugins required by the systests
 PLUGIN_DEPENDENCIES = [
-    "http://updates.jenkins-ci.org/latest/"
+    "http://updates.jenkins.io/latest/"
     "apache-httpcomponents-client-4-api.hpi",
-    "http://updates.jenkins-ci.org/latest/jsch.hpi",
-    "http://updates.jenkins-ci.org/latest/trilead-api.hpi",
-    "http://updates.jenkins-ci.org/latest/workflow-api.hpi",
-    "http://updates.jenkins-ci.org/latest/display-url-api.hpi",
-    "http://updates.jenkins-ci.org/latest/workflow-step-api.hpi",
-    "http://updates.jenkins-ci.org/latest/workflow-scm-step.hpi",
-    "http://updates.jenkins-ci.org/latest/icon-shim.hpi",
-    "http://updates.jenkins-ci.org/latest/junit.hpi",
-    "http://updates.jenkins-ci.org/latest/script-security.hpi",
-    "http://updates.jenkins-ci.org/latest/matrix-project.hpi",
-    "http://updates.jenkins-ci.org/latest/credentials.hpi",
-    "http://updates.jenkins-ci.org/latest/ssh-credentials.hpi",
-    "http://updates.jenkins-ci.org/latest/scm-api.hpi",
-    "http://updates.jenkins-ci.org/latest/mailer.hpi",
-    "http://updates.jenkins-ci.org/latest/git.hpi",
-    "http://updates.jenkins-ci.org/latest/git-client.hpi",
-    "https://updates.jenkins-ci.org/latest/nested-view.hpi",
-    "https://updates.jenkins-ci.org/latest/ssh-slaves.hpi",
-    "https://updates.jenkins-ci.org/latest/structs.hpi",
-    "http://updates.jenkins-ci.org/latest/plain-credentials.hpi",
-    "http://updates.jenkins-ci.org/latest/envinject.hpi",
-    "http://updates.jenkins-ci.org/latest/envinject-api.hpi"
+    "http://updates.jenkins.io/latest/jsch.hpi",
+    "http://updates.jenkins.io/download/plugins/trilead-api/1.0.3/"
+    "trilead-api.hpi",
+    "http://updates.jenkins.io/latest/workflow-api.hpi",
+    "http://updates.jenkins.io/latest/display-url-api.hpi",
+    "http://updates.jenkins.io/latest/workflow-step-api.hpi",
+    "http://updates.jenkins.io/latest/workflow-scm-step.hpi",
+    "http://updates.jenkins.io/latest/icon-shim.hpi",
+    "http://updates.jenkins.io/download/plugins/junit/1.28/junit.hpi",
+    "http://updates.jenkins.io/latest/script-security.hpi",
+    "http://updates.jenkins.io/latest/matrix-project.hpi",
+    "http://updates.jenkins.io/latest/credentials.hpi",
+    "http://updates.jenkins.io/latest/ssh-credentials.hpi",
+    "http://updates.jenkins.io/latest/scm-api.hpi",
+    "http://updates.jenkins.io/latest/mailer.hpi",
+    "http://updates.jenkins.io/latest/git.hpi",
+    "http://updates.jenkins.io/latest/git-client.hpi",
+    "https://updates.jenkins.io/latest/nested-view.hpi",
+    "https://updates.jenkins.io/latest/ssh-slaves.hpi",
+    "https://updates.jenkins.io/latest/structs.hpi",
+    "http://updates.jenkins.io/latest/plain-credentials.hpi",
+    "http://updates.jenkins.io/latest/envinject.hpi",
+    "http://updates.jenkins.io/latest/envinject-api.hpi"
 ]
 
 

--- a/jenkinsapi_tests/systests/test_jenkins.py
+++ b/jenkinsapi_tests/systests/test_jenkins.py
@@ -206,7 +206,7 @@ def test_get_single_plugin_depth_2(jenkins):
 
 
 def test_install_delete_single_plugin_string(jenkins):
-    plugin_name = 'antisamy-markup-formatter'
+    plugin_name = 'simple-theme-plugin'
     plugin_version = 'latest'
     plugin = ('%s@%s') % (plugin_name, plugin_version)
 
@@ -223,7 +223,7 @@ def test_install_delete_single_plugin_string(jenkins):
 
 
 def test_install_delete_single_plugin_object(jenkins):
-    plugin_name = 'antisamy-markup-formatter'
+    plugin_name = 'simple-theme-plugin'
     plugin_version = 'latest'
     plugin = Plugin(('%s@%s') % (plugin_name, plugin_version))
 
@@ -240,7 +240,7 @@ def test_install_delete_single_plugin_object(jenkins):
 
 
 def test_install_delete_multiple_plugins_mix_string_object(jenkins):
-    plugin_one_name = 'antisamy-markup-formatter'
+    plugin_one_name = 'simple-theme-plugin'
     plugin_one_version = 'latest'
     plugin_one = ('%s@%s') % (plugin_one_name, plugin_one_version)
     plugin_two_name = 'docker-commons'
@@ -264,4 +264,4 @@ def test_install_delete_multiple_plugins_mix_string_object(jenkins):
 def test_run_groovy_script(jenkins):
     expected_result = 'Hello world!'
     result = jenkins.run_groovy_script('print "%s"' % expected_result)
-    assert result == 'Hello world!'
+    assert result.strip() == 'Hello world!'


### PR DESCRIPTION
Latest trilead-api refuses to run on LTS Jenkins - use last compatible version
Set all urls to jenkins.io - more stable
Use plugin w/o junit dependence for testing plugin installs. Junit
dependency (even implied to v1.0) causes instability in Jenkins.
Strip result string of groovy exec.