### PR TITLE
Updates Requester to use a Session, maintaining cookies

### DIFF
--- a/jenkinsapi/utils/requester.py
+++ b/jenkinsapi/utils/requester.py
@@ -77,6 +77,7 @@ class Requester(object):
         self.ssl_verify = kwargs.get('ssl_verify', ssl_verify)
         self.cert = kwargs.get('cert', cert)
         self.timeout = kwargs.get('timeout', timeout)
+        self.session = requests.Session()
 
     def get_request_dict(
             self, params=None, data=None, files=None, headers=None, **kwargs):
@@ -140,7 +141,7 @@ class Requester(object):
             allow_redirects=allow_redirects,
             stream=stream
         )
-        return requests.get(self._update_url_scheme(url), **requestKwargs)
+        return self.session.get(self._update_url_scheme(url), **requestKwargs)
 
     def post_url(self, url, params=None, data=None, files=None,
                  headers=None, allow_redirects=True, **kwargs):
@@ -151,7 +152,7 @@ class Requester(object):
             headers=headers,
             allow_redirects=allow_redirects,
             **kwargs)
-        return requests.post(self._update_url_scheme(url), **requestKwargs)
+        return self.session.post(self._update_url_scheme(url), **requestKwargs)
 
     def post_xml_and_confirm_status(
             self, url, params=None, data=None, valid=None):

--- a/jenkinsapi_tests/unittests/test_requester.py
+++ b/jenkinsapi_tests/unittests/test_requester.py
@@ -255,7 +255,7 @@ def test_get_url_get(monkeypatch):
     def fake_get(*args, **kwargs):  # pylint: disable=unused-argument
         return 'SUCCESS'
 
-    monkeypatch.setattr(requests, 'get', fake_get)
+    monkeypatch.setattr(requests.Session, 'get', fake_get)
 
     req = Requester('foo', 'bar')
     response = req.get_url(
@@ -270,7 +270,7 @@ def test_get_url_post(monkeypatch):
     def fake_post(*args, **kwargs):  # pylint: disable=unused-argument
         return 'SUCCESS'
 
-    monkeypatch.setattr(requests, 'post', fake_post)
+    monkeypatch.setattr(requests.Session, 'post', fake_post)
 
     req = Requester('foo', 'bar')
     response = req.post_url(
@@ -285,7 +285,7 @@ def test_post_xml_empty_xml(monkeypatch):
     def fake_post(*args, **kwargs):  # pylint: disable=unused-argument
         return 'SUCCESS'
 
-    monkeypatch.setattr(requests, 'post', fake_post)
+    monkeypatch.setattr(requests.Session, 'post', fake_post)
 
     req = Requester('foo', 'bar')
     with pytest.raises(AssertionError):
@@ -304,7 +304,7 @@ def test_post_xml_and_confirm_status_some_xml(monkeypatch):
     def fake_post(*args, **kwargs):  # pylint: disable=unused-argument
         return FakeResponse()
 
-    monkeypatch.setattr(requests, 'post', fake_post)
+    monkeypatch.setattr(requests.Session, 'post', fake_post)
 
     req = Requester('foo', 'bar')
     ret = req.post_xml_and_confirm_status(
@@ -319,7 +319,7 @@ def test_post_and_confirm_status_empty_data(monkeypatch):
     def fake_post(*args, **kwargs):  # pylint: disable=unused-argument
         return 'SUCCESS'
 
-    monkeypatch.setattr(requests, 'post', fake_post)
+    monkeypatch.setattr(requests.Session, 'post', fake_post)
 
     req = Requester('foo', 'bar')
     with pytest.raises(AssertionError):
@@ -338,7 +338,7 @@ def test_post_and_confirm_status_some_data(monkeypatch):
     def fake_post(*args, **kwargs):  # pylint: disable=unused-argument
         return FakeResponse()
 
-    monkeypatch.setattr(requests, 'post', fake_post)
+    monkeypatch.setattr(requests.Session, 'post', fake_post)
 
     req = Requester('foo', 'bar')
     ret = req.post_and_confirm_status(
@@ -359,7 +359,7 @@ def test_post_and_confirm_status_bad_result(monkeypatch):
     def fake_post(*args, **kwargs):  # pylint: disable=unused-argument
         return FakeResponse()
 
-    monkeypatch.setattr(requests, 'post', fake_post)
+    monkeypatch.setattr(requests.Session, 'post', fake_post)
 
     req = Requester('foo', 'bar')
     with pytest.raises(JenkinsAPIException):
@@ -378,7 +378,7 @@ def test_get_and_confirm_status(monkeypatch):
     def fake_get(*args, **kwargs):  # pylint: disable=unused-argument
         return FakeResponse()
 
-    monkeypatch.setattr(requests, 'get', fake_get)
+    monkeypatch.setattr(requests.Session, 'get', fake_get)
 
     req = Requester('foo', 'bar')
     ret = req.get_and_confirm_status(
@@ -398,7 +398,7 @@ def test_get_and_confirm_status_bad_result(monkeypatch):
     def fake_get(*args, **kwargs):  # pylint: disable=unused-argument
         return FakeResponse()
 
-    monkeypatch.setattr(requests, 'get', fake_get)
+    monkeypatch.setattr(requests.Session, 'get', fake_get)
 
     req = Requester('foo', 'bar', baseurl='http://dummy')
     with pytest.raises(JenkinsAPIException):


### PR DESCRIPTION
At least as of jenkins 2.176.3 csrf check requires the cookie
issued when requesting a csrf token to also be present in requests.

Prevents "Error 403 No valid crumb was included in the request"