### PR TITLE
Create Node by providing predetermined configuration

### DIFF
--- a/jenkinsapi/jenkins.py
+++ b/jenkinsapi/jenkins.py
@@ -30,12 +30,10 @@ from jenkinsapi.jenkinsbase import JenkinsBase
 from jenkinsapi.custom_exceptions import JenkinsAPIException
 from jenkinsapi.utils.crumb_requester import CrumbRequester
 
-
 log = logging.getLogger(__name__)
 
 
 class Jenkins(JenkinsBase):
-
     """
     Represents a jenkins environment.
     """
@@ -79,7 +77,7 @@ class Jenkins(JenkinsBase):
     def _poll(self, tree=None):
         url = self.python_api_url(self.baseurl)
         return self.get_data(url, tree='jobs[name,color,url]'
-                             if not tree else tree)
+        if not tree else tree)
 
     def _poll_if_needed(self):
         if self.lazy and self._data is None:
@@ -353,6 +351,17 @@ class Jenkins(JenkinsBase):
         }
         return self.nodes.create_node(name, node_dict)
 
+    def create_node_with_config(self, name: str, config: dict):
+        """
+        Create a new slave node with specific configuration.
+        Config should be resemble the output of node.get_node_attributes()
+        :param str name: name of slave
+        :param dict config: Node attributes for Jenkins API request to create node
+            (See function output Node.get_node_attributes())
+        :return: node obj
+        """
+        return self.nodes.create_node_with_config(name=name, config=config)
+
     def get_plugins_url(self, depth):
         # This only ever needs to work on the base object
         return '%s/pluginManager/api/python?depth=%i' % (self.baseurl, depth)
@@ -377,7 +386,7 @@ class Jenkins(JenkinsBase):
             warnings.warn(
                 "System reboot is required, but automatic reboot is disabled. "
                 "Please reboot manually."
-                )
+            )
 
     def install_plugins(self, plugin_list, restart=True, force_restart=False,
                         wait_for_reboot=True, no_reboot_warning=False):
@@ -399,7 +408,7 @@ class Jenkins(JenkinsBase):
             warnings.warn(
                 "System reboot is required, but automatic reboot is disabled. "
                 "Please reboot manually."
-                )
+            )
 
     def delete_plugin(self, plugin, restart=True, force_restart=False,
                       wait_for_reboot=True, no_reboot_warning=False):
@@ -420,7 +429,7 @@ class Jenkins(JenkinsBase):
             warnings.warn(
                 "System reboot is required, but automatic reboot is disabled. "
                 "Please reboot manually."
-                )
+            )
 
     def delete_plugins(self, plugin_list, restart=True, force_restart=False,
                        wait_for_reboot=True, no_reboot_warning=False):
@@ -441,7 +450,7 @@ class Jenkins(JenkinsBase):
             warnings.warn(
                 "System reboot is required, but automatic reboot is disabled. "
                 "Please reboot manually."
-                )
+            )
 
     def safe_restart(self, wait_for_reboot=True):
         """ restarts jenkins when no jobs are running """
@@ -651,7 +660,7 @@ class Jenkins(JenkinsBase):
 
     def use_auth_cookie(self):
         assert (self.username and
-                self.baseurl), 'Please provide jenkins url, username '\
+                self.baseurl), 'Please provide jenkins url, username ' \
                                'and password to get the session ID cookie.'
 
         login_url = 'j_acegi_security_check'

--- a/jenkinsapi/jenkins.py
+++ b/jenkinsapi/jenkins.py
@@ -353,7 +353,7 @@ class Jenkins(JenkinsBase):
         }
         return self.nodes.create_node(name, node_dict)
 
-    def create_node_with_config(self, name: str, config: dict):
+    def create_node_with_config(self, name, config):
         """
         Create a new slave node with specific configuration.
         Config should be resemble the output of node.get_node_attributes()

--- a/jenkinsapi/jenkins.py
+++ b/jenkinsapi/jenkins.py
@@ -30,10 +30,12 @@ from jenkinsapi.jenkinsbase import JenkinsBase
 from jenkinsapi.custom_exceptions import JenkinsAPIException
 from jenkinsapi.utils.crumb_requester import CrumbRequester
 
+
 log = logging.getLogger(__name__)
 
 
 class Jenkins(JenkinsBase):
+
     """
     Represents a jenkins environment.
     """
@@ -77,7 +79,7 @@ class Jenkins(JenkinsBase):
     def _poll(self, tree=None):
         url = self.python_api_url(self.baseurl)
         return self.get_data(url, tree='jobs[name,color,url]'
-        if not tree else tree)
+                             if not tree else tree)
 
     def _poll_if_needed(self):
         if self.lazy and self._data is None:
@@ -386,7 +388,7 @@ class Jenkins(JenkinsBase):
             warnings.warn(
                 "System reboot is required, but automatic reboot is disabled. "
                 "Please reboot manually."
-            )
+                )
 
     def install_plugins(self, plugin_list, restart=True, force_restart=False,
                         wait_for_reboot=True, no_reboot_warning=False):
@@ -408,7 +410,7 @@ class Jenkins(JenkinsBase):
             warnings.warn(
                 "System reboot is required, but automatic reboot is disabled. "
                 "Please reboot manually."
-            )
+                )
 
     def delete_plugin(self, plugin, restart=True, force_restart=False,
                       wait_for_reboot=True, no_reboot_warning=False):
@@ -429,7 +431,7 @@ class Jenkins(JenkinsBase):
             warnings.warn(
                 "System reboot is required, but automatic reboot is disabled. "
                 "Please reboot manually."
-            )
+                )
 
     def delete_plugins(self, plugin_list, restart=True, force_restart=False,
                        wait_for_reboot=True, no_reboot_warning=False):
@@ -450,7 +452,7 @@ class Jenkins(JenkinsBase):
             warnings.warn(
                 "System reboot is required, but automatic reboot is disabled. "
                 "Please reboot manually."
-            )
+                )
 
     def safe_restart(self, wait_for_reboot=True):
         """ restarts jenkins when no jobs are running """
@@ -660,7 +662,7 @@ class Jenkins(JenkinsBase):
 
     def use_auth_cookie(self):
         assert (self.username and
-                self.baseurl), 'Please provide jenkins url, username ' \
+                self.baseurl), 'Please provide jenkins url, username '\
                                'and password to get the session ID cookie.'
 
         login_url = 'j_acegi_security_check'

--- a/jenkinsapi/nodes.py
+++ b/jenkinsapi/nodes.py
@@ -155,7 +155,7 @@ class Nodes(JenkinsBase):
         self.poll()
         return self[name]
 
-    def create_node_with_config(self, name: str, config: dict):
+    def create_node_with_config(self, name, config):
         """
         Create a new slave node with specific configuration.
         Config should be resemble the output of node.get_node_attributes()
@@ -169,8 +169,9 @@ class Nodes(JenkinsBase):
 
         if type(config) is not dict:
             return None
-
-        url = f'{self.jenkins.baseurl}/computer/doCreateItem?{urlencode(config)}'
+        url = ('%s/computer/doCreateItem?%s'
+               % (self.jenkins.baseurl,
+                  urlencode(config)))
         data = {'json': urlencode(config)}
         self.jenkins.requester.post_and_confirm_status(url, data=data)
         self.poll()

--- a/jenkinsapi/nodes.py
+++ b/jenkinsapi/nodes.py
@@ -167,7 +167,7 @@ class Nodes(JenkinsBase):
         if name in self:
             return self[name]
 
-        if type(config) is not dict:
+        if not isinstance(config, dict):
             return None
         url = ('%s/computer/doCreateItem?%s'
                % (self.jenkins.baseurl,

--- a/jenkinsapi/nodes.py
+++ b/jenkinsapi/nodes.py
@@ -14,6 +14,7 @@ log = logging.getLogger(__name__)
 
 
 class Nodes(JenkinsBase):
+
     """
     Class to hold information on a collection of nodes
     """
@@ -24,8 +25,8 @@ class Nodes(JenkinsBase):
         """
         self.jenkins = jenkins_obj
         JenkinsBase.__init__(self, baseurl.rstrip('/')
-        if '/computer' in baseurl
-        else baseurl.rstrip('/') + '/computer')
+                             if '/computer' in baseurl
+                             else baseurl.rstrip('/') + '/computer')
 
     def get_jenkins_obj(self):
         return self.jenkins

--- a/jenkinsapi/nodes.py
+++ b/jenkinsapi/nodes.py
@@ -14,7 +14,6 @@ log = logging.getLogger(__name__)
 
 
 class Nodes(JenkinsBase):
-
     """
     Class to hold information on a collection of nodes
     """
@@ -25,8 +24,8 @@ class Nodes(JenkinsBase):
         """
         self.jenkins = jenkins_obj
         JenkinsBase.__init__(self, baseurl.rstrip('/')
-                             if '/computer' in baseurl
-                             else baseurl.rstrip('/') + '/computer')
+        if '/computer' in baseurl
+        else baseurl.rstrip('/') + '/computer')
 
     def get_jenkins_obj(self):
         return self.jenkins
@@ -151,6 +150,27 @@ class Nodes(JenkinsBase):
                % (self.jenkins.baseurl,
                   urlencode(node.get_node_attributes())))
         data = {'json': urlencode(node.get_node_attributes())}
+        self.jenkins.requester.post_and_confirm_status(url, data=data)
+        self.poll()
+        return self[name]
+
+    def create_node_with_config(self, name: str, config: dict):
+        """
+        Create a new slave node with specific configuration.
+        Config should be resemble the output of node.get_node_attributes()
+        :param str name: name of slave
+        :param dict config: Node attributes for Jenkins API request to create node
+            (See function output Node.get_node_attributes())
+        :return: node obj
+        """
+        if name in self:
+            return self[name]
+
+        if type(config) is not dict:
+            return None
+
+        url = f'{self.jenkins.baseurl}/computer/doCreateItem?{urlencode(config)}'
+        data = {'json': urlencode(config)}
         self.jenkins.requester.post_and_confirm_status(url, data=data)
         self.poll()
         return self[name]


### PR DESCRIPTION
The current workflow in creating a new node allows the user to provide a small and limited array of configurations
```python
jenkins.create_node(name, num_executors=2, node_description=None,
                    remote_fs='/var/lib/jenkins',
                    labels=None, exclusive=False)
...
node_dict = {
            'num_executors': num_executors,
            'node_description': node_description,
            'remote_fs': remote_fs,
            'labels': labels,
            'exclusive': exclusive
        }
```
However, in order to configure the node to exactly how I would like it, I would have to create it, then send a modify step. 

This pull request allows an advanced user the ability to create the node exactly, right from the start. This is important because I have my configurations in source control so every new agent is created the same.