### PR TITLE
Handle missing standard ports in response (i.e. 443/80) during job invoke 

### DIFF
--- a/jenkinsapi/job.py
+++ b/jenkinsapi/job.py
@@ -218,8 +218,11 @@ class Job(JenkinsBase, MutableJenkinsThing):
         # https://server.domain.com/jenkins/job/my_team/api/
         #
         queue_baseurl_candidates = [self.jenkins.baseurl]
-        scheme, netloc, path, _, query, frag = \
-            urlparse.urlparse(self.jenkins.baseurl)
+        parsed = urlparse.urlparse(self.jenkins.baseurl)
+        scheme, netloc, path, _, query, frag = parsed
+
+        queue_baseurl_candidates.append(
+            urlparse.urlunsplit([scheme, parsed.hostname, path, query, frag]))
         while path:
             path = '/'.join(path.rstrip('/').split('/')[:-1])
             queue_baseurl_candidates.append(


### PR DESCRIPTION
Hi all,

Thanks for the great python program. I really appreciate all the functionality and it is an essential part of our jobs.
In my setup we have a Jenkins instance running behind an HA proxy so that we don't use the normal 8080 port for Jenkins but instead the https standard port 443. In the particular case that you set the baseurl to include the standardport it will fail when checking for the queue URL, because the response location / redirect does not include a port anymore.
Solves #732 

I am not sure if this should handled here or if already when creating a Jenkins/Job instance we should modify the baseurl and remove standard ports. I'll leave this up to you. Please let me know which fits you best.

