### PR TITLE
fix job url

### DIFF
--- a/jenkinsapi/jenkinsbase.py
+++ b/jenkinsapi/jenkinsbase.py
@@ -98,6 +98,8 @@ class JenkinsBase(object):
             if 'color' not in job.keys():
                 jobs.remove(job)
                 jobs += self.process_job_folder(job, self.baseurl)
+            else:
+                job["url"] = '%s/job/%s' % (self.baseurl, urlquote(job['name']))
 
         return jobs
 


### PR DESCRIPTION
this bug occurs when
1. We use this package in kubernetes container
2. and baseurl is kubernetes service url

eg:
1. maybe jenkins domain is "http://jenkins.demo.com"
2. but we assign baseurl with kubernetes service url "http://jenkins.jenkins"

```
code like this
j = Jenkins("http://jenkins.jenkins/job/folder")
"exist_job" in j          # this will be False but wish be True
```