### PR TITLE
Prevent MD5 warnings going to the root logger.

### DIFF
--- a/jenkinsapi/fingerprint.py
+++ b/jenkinsapi/fingerprint.py
@@ -21,7 +21,6 @@ class Fingerprint(JenkinsBase):
     RE_MD5 = re.compile("^([0-9a-z]{32})$")
 
     def __init__(self, baseurl, id_, jenkins_obj):
-        logging.basicConfig()
         self.jenkins_obj = jenkins_obj
         assert self.RE_MD5.search(id_), ("%s does not look like "
                                          "a valid id" % id_)
@@ -56,7 +55,7 @@ class Fingerprint(JenkinsBase):
             # extract the status code from it
             response_obj = err.response
             if response_obj.status_code == 404:
-                logging.warning(
+                log.warning(
                     "MD5 cannot be checked if fingerprints are not "
                     "enabled")
                 self.unknown = True


### PR DESCRIPTION
I kept meaning to find out where MD5 warnings in the root logger were coming from - turns out it's this module. It's a trivial change, of course. I checked for other occurrences of the same issue in the code and didn't see any. I also looked at the tests but the logger handling isn't tested so no changes were needed there.

The documentation suggests that the call to basicConfig() isn't needed - it'll be called automatically if necessary. The other similar files aren't calling it.

Hope this helps!