### PR TITLE
Abort QueueItem.block_until_building after 100 HTTPErrors

### DIFF
--- a/jenkinsapi/jenkinsbase.py
+++ b/jenkinsapi/jenkinsbase.py
@@ -78,8 +78,8 @@ class JenkinsBase(object):
 
         response = requester.get_url(url, params)
         if response.status_code != 200:
-            logger.error('Failed request at %s with params: %s %s',
-                         url, params, tree if tree else '')
+            logger.error('Failed request at %s with params: %s %s - HTTP %s',
+                         url, params, tree if tree else '', response.status_code)
             response.raise_for_status()
         try:
             return ast.literal_eval(response.text)


### PR DESCRIPTION
This aim to avoid this kind of situation:
```
2020-12-08 02:27:39,955 [ERROR] jenkinsbase.py:81 - Failed request at https://jenkins.example.com/queue/item/20799/api/python with params: None 
2020-12-08 02:27:39,956 [DEBUG] queue.py:153 - 503 Server Error: Service Unavailable for url: https://jenkins.example.com/queue/item/20799/api/python
2020-12-08 02:27:41,429 [ERROR] jenkinsbase.py:81 - Failed request at https://jenkins.example.com/queue/item/20798/api/python with params: None 
2020-12-08 02:27:41,429 [DEBUG] queue.py:153 - 503 Server Error: Service Unavailable for url: https://jenkins.example.com/queue/item/20798/api/python
2020-12-08 02:27:48,277 [ERROR] jenkinsbase.py:81 - Failed request at https://jenkins.example.com/queue/item/20798/api/python with params: None 
2020-12-08 02:27:48,277 [DEBUG] queue.py:153 - 404 Client Error: Not Found for url: https://jenkins.example.com/queue/item/20798/api/python
2020-12-08 02:27:48,278 [ERROR] jenkinsbase.py:81 - Failed request at https://jenkins.example.com/queue/item/20799/api/python with params: None 
2020-12-08 02:27:48,278 [DEBUG] queue.py:153 - 404 Client Error: Not Found for url: https://jenkins.example.com/queue/item/20799/api/python
2020-12-08 02:27:55,125 [ERROR] jenkinsbase.py:81 - Failed request at https://jenkins.example.com/queue/item/20798/api/python with params: None 
2020-12-08 02:27:55,125 [DEBUG] queue.py:153 - 404 Client Error: Not Found for url: https://jenkins.example.com/queue/item/20798/api/python
2020-12-08 02:27:55,127 [ERROR] jenkinsbase.py:81 - Failed request at https://jenkins.example.com/queue/item/20799/api/python with params: None 
2020-12-08 02:27:55,127 [DEBUG] queue.py:153 - 404 Client Error: Not Found for url: https://jenkins.example.com/queue/item/20799/api/python
```

With MANY HTTP errors occuring, and nothing ever noticing the issue :
```
$ grep -cF '503 Server Error' execution.log
384
$ grep -cF '404 Client Error' execution.log
1261
```

This PR aims to detect a problem after Jenkins returned 100 HTTP errors while polling the same job (the value is configurable)
