### PR TITLE
Accounting for the new versioning style of the credentials plugin.

### DIFF
--- a/jenkinsapi/jenkins.py
+++ b/jenkinsapi/jenkins.py
@@ -606,7 +606,7 @@ class Jenkins(JenkinsBase):
         if 'credentials' not in self.plugins:
             raise JenkinsAPIException('Credentials plugin not installed')
 
-        if int(self.plugins['credentials'].version[0:1]) == 1:
+        if int(self.plugins['credentials'].version.split('.')) == 1:
             url = '%s/credential-store/domain/_/' % self.baseurl
             return Credentials(url, self)
 

--- a/jenkinsapi/jenkins.py
+++ b/jenkinsapi/jenkins.py
@@ -606,7 +606,7 @@ class Jenkins(JenkinsBase):
         if 'credentials' not in self.plugins:
             raise JenkinsAPIException('Credentials plugin not installed')
 
-        if int(self.plugins['credentials'].version.split('.')) == 1:
+        if int(self.plugins['credentials'].version.split('.')[0]) == 1:
             url = '%s/credential-store/domain/_/' % self.baseurl
             return Credentials(url, self)
 


### PR DESCRIPTION
Starting in December 2021, after version 2.6.2, the `credentials` plugin adopted a new versioning scheme:

https://github.com/jenkinsci/credentials-plugin/releases

1055.v1346ba467ba1
1061.vb_1fceb_58fa_18
1074.v60e6c29b_b_44b_

Because the versions start with the character '1', `jenkinsapi` considers that the same as versions 1.x.y, and tries to use the legacy URL path.  This is a quick fix to parse the version number on `.` and consider the whole first component.