### PR TITLE
jenkins: support latest credentials plugin version

### DIFF
--- a/jenkinsapi/jenkins.py
+++ b/jenkinsapi/jenkins.py
@@ -606,7 +606,7 @@ class Jenkins(JenkinsBase):
         if 'credentials' not in self.plugins:
             raise JenkinsAPIException('Credentials plugin not installed')
 
-        if int(self.plugins['credentials'].version[0:1]) == 1:
+        if self.plugins['credentials'].version.startswith('1.'):
             url = '%s/credential-store/domain/_/' % self.baseurl
             return Credentials(url, self)
 


### PR DESCRIPTION
The last version the Credentials plugin which starts with number '2' was 2.6.2, later the versioning has been switched to the newer approach, for example,
latest for the moment is "1129.vef26f5df883c", refer https://plugins.jenkins.io/credentials/#releases

This patch adopts the code to the changes above.

Fixes: #824

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>