### PR TITLE
Clarify python version compatibility

### DIFF
--- a/doc/source/rules_for_contributors.rst
+++ b/doc/source/rules_for_contributors.rst
@@ -6,8 +6,8 @@ The JenkinsAPI project welcomes contributions via GitHub. Please bear in mind th
 Python compatibility
 --------------------
 
-The project currently targets Python 2.6 and Python 2.7. Support for Python 3.x will be introduced soon. Please do not add any features which
-will break our supported Python 2.x versions or make it harder for us to migrate to Python 3.x
+The project currently targets Python 2.7, and Python 3.4 to 3.6. Please do not add any features which
+will break our Python 2.7 version or are not Python 2.7 *and* 3+ compatible. 
 
 Test Driven Development
 -----------------------


### PR DESCRIPTION
Someone pointed out this version oversight in the docs. @lechat, if you don't want to take a stance on Python2 and Python3 compatibility, deprecation schedules, etc., I understand. I just want to update the docs so they are consistent with the packages published on PyPi.