### PR TITLE
CLI type hinting and minor refactor

### DIFF
--- a/jenkinsapi/command_line/__init__.py
+++ b/jenkinsapi/command_line/__init__.py
@@ -1,3 +1,3 @@
 """
-__init__,py for commandline module
+Module __init__ for command_line.
 """

--- a/jenkinsapi/command_line/jenkinsapi_version.py
+++ b/jenkinsapi/command_line/jenkinsapi_version.py
@@ -1,10 +1,17 @@
-""" jenkinsapi.command_line.jenkinsapi_version
 """
+Invokable module used to print jenkinsapi version.
+"""
+
+
 from jenkinsapi import __version__ as version
 import sys
 
 
 def main():
+    # type: () -> None
+    """
+    Writes the current jenkinsapi version to stdout.
+    """
     sys.stdout.write(version)
 
 


### PR DESCRIPTION
Problem: The type hinting for jenkinsapi.command_line is a little lacking. In addition, the use of asserts in non-test code is undesirable.

Solution: Introduce type hinting following PEP-484 for straddling code and refactor asserts to use proper conditionals instead.