### PR TITLE
Support for using unicode characters in update_config()

### DIFF
--- a/jenkinsapi/job.py
+++ b/jenkinsapi/job.py
@@ -627,7 +627,7 @@ class Job(JenkinsBase, MutableJenkinsThing):
     def get_config_xml_url(self):
         return "%s/config.xml" % self.baseurl
 
-    def update_config(self, config, full_response=False, encoding='utf-8'):
+    def update_config(self, config, full_response=False, encoding="utf-8"):
         """
         Update the config.xml to the job
         Also refresh the ElementTree object since the config has changed
@@ -637,7 +637,9 @@ class Job(JenkinsBase, MutableJenkinsThing):
         """
         url = self.get_config_xml_url()
         config = str(config)  # cast unicode in case of Python 2
-        response = self.jenkins.requester.post_url(url, params={}, data=config.encode(encoding))
+        response = self.jenkins.requester.post_url(
+            url, params={}, data=config.encode(encoding)
+        )
         self._element_tree = ET.fromstring(config)
 
         if full_response:

--- a/jenkinsapi/job.py
+++ b/jenkinsapi/job.py
@@ -627,7 +627,7 @@ class Job(JenkinsBase, MutableJenkinsThing):
     def get_config_xml_url(self):
         return "%s/config.xml" % self.baseurl
 
-    def update_config(self, config, full_response=False):
+    def update_config(self, config, full_response=False, encoding='utf-8'):
         """
         Update the config.xml to the job
         Also refresh the ElementTree object since the config has changed
@@ -637,7 +637,7 @@ class Job(JenkinsBase, MutableJenkinsThing):
         """
         url = self.get_config_xml_url()
         config = str(config)  # cast unicode in case of Python 2
-        response = self.jenkins.requester.post_url(url, params={}, data=config)
+        response = self.jenkins.requester.post_url(url, params={}, data=config.encode(encoding))
         self._element_tree = ET.fromstring(config)
 
         if full_response:


### PR DESCRIPTION
Hi!
Currently, `update_config()` converts the `config` to `str` type without encoding format.
So it does not support unicode characters. For example:
```py
>>> jk.get_job('job1').update_config('中文') 
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\Leo\AppData\Local\Programs\Python\Python39\lib\site-packages\jenkinsapi\job.py", line 640, in update_config
    response = self.jenkins.requester.post_url(url, params={}, data=config)
  ...
  File "C:\Users\Leo\AppData\Local\Programs\Python\Python39\lib\http\client.py", line 164, in _encode
    raise UnicodeEncodeError(
UnicodeEncodeError: 'latin-1' codec can't encode characters in position 0-1: Body ('中文') is not valid Latin-1. Use body.encode('utf-8') if you want to send it encoded in UTF-8.
```
So I submitted this PR to encode the config in utf-8 by default.
Looking forward to your review.