### PR TITLE
fix: jenkinsapi crashing jenkins_is_unavaiable

### DIFF
--- a/jenkinsapi/jenkins.py
+++ b/jenkinsapi/jenkins.py
@@ -550,9 +550,15 @@ class Jenkins(JenkinsBase):
     def __jenkins_is_unavailable(self):
         while True:
             try:
-                self.requester.get_and_confirm_status(
-                    self.baseurl, valid=[503, 500]
+                res = self.requester.get_and_confirm_status(
+                    self.baseurl, valid=[503, 500, 200]
                 )
+                # If there is a running job in Jenkins, the system message will
+                # pop up but the Jenkins instance will return 200
+                if res.status_code == 200 and "Jenkins is going to shut down" in \
+                    str(res.content, encoding="utf-8"):
+                    time.sleep(1)
+                    continue
                 return True
             except ConnectionError:
                 # This is also a possibility while Jenkins is restarting

--- a/jenkinsapi/jenkins.py
+++ b/jenkinsapi/jenkins.py
@@ -555,8 +555,11 @@ class Jenkins(JenkinsBase):
                 )
                 # If there is a running job in Jenkins, the system message will
                 # pop up but the Jenkins instance will return 200
-                if res.status_code == 200 and "Jenkins is going to shut down" in \
-                    str(res.content, encoding="utf-8"):
+                if (
+                    res.status_code == 200
+                    and "Jenkins is going to shut down"
+                    in str(res.content, encoding="utf-8")
+                ):
                     time.sleep(1)
                     continue
                 return True


### PR DESCRIPTION
This PR addresses the issue when Jenkins has a running job and /safeRestart is called.

![image](https://github.com/pycontribs/jenkinsapi/assets/37652070/093ae1e5-5def-4360-a6de-f393c50794ad)

Fixes: #844 