### PR TITLE
Fixing plugin dependencies

### DIFF
--- a/jenkinsapi_tests/systests/conftest.py
+++ b/jenkinsapi_tests/systests/conftest.py
@@ -59,6 +59,9 @@ PLUGIN_DEPENDENCIES = [
     "http://updates.jenkins.io/latest/workflow-support.hpi",
     "http://updates.jenkins.io/latest/jquery3-api.hpi",
     "http://updates.jenkins.io/latest/checks-api.hpi",
+    "http://updates.jenkins.io/latest/javax-activation-api.hpi",
+    "http://updates.jenkins.io/latest/jaxb.hpi",
+    "http://updates.jenkins.io/latest/instance-identity.hpi",
 ]
 
 


### PR DESCRIPTION
It looks like `stable` version of Jenkins has a bug with plugins API call that was fixed in `latest` version. This causes all tests for `stable` Jenkins to fail.