### PR TITLE
feature: add launch method to Node class

### DIFF
--- a/jenkinsapi/node.py
+++ b/jenkinsapi/node.py
@@ -284,9 +284,7 @@ class Node(JenkinsBase):
                 "It is not allowed to manually launch this node."
             )
 
-        url = (
-            self.baseurl + "/launchSlaveAgent"
-        )
+        url = self.baseurl + "/launchSlaveAgent"
         html_result = self.jenkins.requester.post_and_confirm_status(
             url, data={}
         )

--- a/jenkinsapi/node.py
+++ b/jenkinsapi/node.py
@@ -269,6 +269,29 @@ class Node(JenkinsBase):
                     % (data["offline"], data["temporarilyOffline"])
                 )
 
+    def launch(self) -> None:
+        """
+        Tries to launch a connection with the slave if it is currently
+        disconnected. Because launching a connection with the slave does not
+        mean it is online (a slave can be launched, but set offline), this
+        function does not check if the launch was successful.
+        """
+        if not self._data["launchSupported"]:
+            raise AssertionError("The node does not support manually launch.")
+
+        if not self._data["manualLaunchAllowed"]:
+            raise AssertionError(
+                "It is not allowed to manually launch this node."
+            )
+
+        url = (
+            self.baseurl + "/launchSlaveAgent"
+        )
+        html_result = self.jenkins.requester.post_and_confirm_status(
+            url, data={}
+        )
+        log.debug(html_result)
+
     def toggle_temporarily_offline(
         self, message="requested from jenkinsapi"
     ) -> None:


### PR DESCRIPTION
Add support for the `/computes/{node-name}/launchSlaveAgent` endpoint. For slaves that support launching (e.g. SSH slaves), this allows triggering a new try to connect the slave with jenkins. We need this, because setting a node online does not trigger a reconnect.