### PR TITLE
Do not make use of pytest.warns(None)

### DIFF
--- a/jenkinsapi_tests/unittests/test_build.py
+++ b/jenkinsapi_tests/unittests/test_build.py
@@ -277,6 +277,7 @@ def test_build_env_vars_other_exception(monkeypatch, build):
 
     with pytest.raises(Exception) as excinfo:
         with warnings.catch_warnings():
+            warnings.simplefilter("error")
             build.get_env_vars()
     assert "" == str(excinfo.value)
 


### PR DESCRIPTION
pytest.warns(None) is an anti-pattern, and there are easier ways to accomplish both cases with how the code is leveraging pytest.warns(). Firstly, it can match on a specific warning and will assert that the warning is raised -- and it doesn't need to be used if we want to assert code raises no warnings, the standard library can do that directly. Furthermore, pytest.warns(None) is an error in Pytest 8 and above.