### PR TITLE
ci: fix issue causing runner to crash in setup

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -13,10 +13,6 @@ on:
     branches: [ "master" ]
   workflow_dispatch: # allow manual run
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   build:
 
@@ -29,7 +25,7 @@ jobs:
 
     steps:
     - name: Harden Runner
-      uses: step-security/harden-runner@1f99358870fe1c846a3ccba386cc2b2246836776 # v2.2.1
+      uses: step-security/harden-runner@5c7944e73c4c2a096b17a9cb74d65b6c2bbafbde # v2.9.1
       with:
         egress-policy: block
         allowed-endpoints: >
@@ -40,6 +36,8 @@ jobs:
           ftp-nyc.osuosl.org:443
           get.jenkins.io:443
           github.com:443
+          api.github.com:443
+          int.api.stepsecurity.io:443
           mirror.xmission.com:443
           motd.ubuntu.com:443
           packages.microsoft.com:443
@@ -56,23 +54,7 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
-
-    - name: Get pip cache dir
-      id: pip-cache
-      run: |
-        echo "::set-output name=dir::$(pip cache dir)"
-
-    - name: Setup the Pip cache
-      uses: actions/cache@v3
-      with:
-        path: ${{ steps.pip-cache.outputs.dir }}
-        key: >-
-          ${{ matrix.python-version }}-pip-${{ hashFiles('setup.cfg') }}-${{
-          hashFiles('setup.py') }}-${{ hashFiles('tox.ini') }}-${{
-          hashFiles('.pre-commit-config.yaml') }}
-        restore-keys: |
-          ${{ matrix.python-version }}-pip-
-          ${{ matrix.python-version }}-
+        cache: 'pip' # caching pip dependencies
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,6 +11,7 @@ on:
       - '**.yml'
   pull_request:
     branches: [ "master" ]
+  workflow_dispatch: # allow manual run
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
* caused by harden runner issues
    * set-output step also has been deprecated in github actions

Two failing pytest tests in latest here https://github.com/clintonsteiner/jenkinsapi/actions/runs/12392484959/job/34591759706

Solves this issue
https://github.com/pycontribs/jenkinsapi/issues/854