### PR TITLE
remove "six" from example

### DIFF
--- a/examples/low_level/post_watcher.py
+++ b/examples/low_level/post_watcher.py
@@ -9,16 +9,10 @@ or simply
 Serving on localhost:8000
 
 You can use this to test GET and POST methods.
-
-In order to run this example you will need the six compatibility library
-install it with pip before running this script:
-
-```
-pip install six
-```
 """
 
-from six.moves import SimpleHTTPServer, socketserver
+import http.server as SimpleHTTPServer
+import socketserver
 import logging
 import cgi
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ requires-python = ">=3.8"
 dependencies = [
     "pytz>=2014.4",
     "requests>=2.3.0",
-    "six>=1.10.0",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
this remove the last bit of stray Python2 compatibility