### PR TITLE
Potential fix for code scanning alert no. 5: Binding a socket to all network interfaces

### DIFF
--- a/jenkinsapi/utils/jenkins_launcher.py
+++ b/jenkinsapi/utils/jenkins_launcher.py
@@ -86,7 +86,7 @@ class JenkinsLancher(object):
             import socket
 
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            sock.bind(("", 0))
+            sock.bind(("127.0.0.1", 0))
             sock.listen(1)
             port = sock.getsockname()[1]
             sock.close()


### PR DESCRIPTION
Potential fix for [https://github.com/pycontribs/jenkinsapi/security/code-scanning/5](https://github.com/pycontribs/jenkinsapi/security/code-scanning/5)

To fix this problem, change the binding address in `sock.bind(("", 0))` to bind explicitly to `127.0.0.1`, limiting the exposure of the socket to the loopback interface and preventing any possibility (however brief) of external access. This is a change to a single line (line 89 of `jenkinsapi/utils/jenkins_launcher.py`). No new imports or major rewrites are necessary since the rest of the code logic (choosing an ephemeral port and closing the socket) remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
