### PR TITLE
fix: restrict CI builds to master and fix flaky queue test

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -2,6 +2,7 @@ name: CI_TEST
 
 on:
   push:
+    branches: [master]
   pull_request:
     branches: [master]
   workflow_dispatch: # allow manual run

--- a/jenkinsapi_tests/systests/test_queue.py
+++ b/jenkinsapi_tests/systests/test_queue.py
@@ -77,13 +77,11 @@ def test_start_and_stop_long_running_job(jenkins):
     time.sleep(1)
     assert j.is_queued_or_running() is True
 
-    while j.is_queued():
-        time.sleep(0.5)
+    # Get queue item and wait for it to transition to a build
+    queue_item = j.get_queue_item()
+    build = queue_item.block_until_building()
 
-    if j.is_running():
-        time.sleep(1)
-
-    j.get_first_build().stop()
+    build.stop()
     time.sleep(1)
     assert j.is_queued_or_running() is False
 


### PR DESCRIPTION
- Configure python-package.yml to run only on pushes to master and PRs to master (was running on all branch pushes)
- Fix flaky test_start_and_stop_long_running_job by using queue_item.block_until_building() to wait for build creation instead of calling get_first_build() which could raise NoBuildData